### PR TITLE
Add Grinch Heist minigame

### DIFF
--- a/src/commands/Feedback.ts
+++ b/src/commands/Feedback.ts
@@ -29,7 +29,9 @@ export class Feedback implements ISlashCommand {
 
     return ctx.reply(
       new MessageBuilder().addEmbed(
-        new EmbedBuilder().setTitle(`Thanks for submitting your feedback! We'll look into it. If you have a question, please join our support server https://discord.gg/KEJwtK5Z8k`)
+        new EmbedBuilder().setTitle(
+          `Thanks for submitting your feedback! We'll look into it. If you have a question, please join our support server https://discord.gg/KEJwtK5Z8k`
+        )
       )
     );
   };

--- a/src/commands/Tree.ts
+++ b/src/commands/Tree.ts
@@ -19,6 +19,7 @@ import { SantaPresentMinigame } from "../minigames/SantaPresentMinigame";
 import { HotCocoaMinigame } from "../minigames/HotCocoaMinigame";
 import { GiftUnwrappingMinigame } from "../minigames/GiftUnwrappingMinigame";
 import { SnowballFightMinigame } from "../minigames/SnowballFightMinigame";
+import { GrinchHeistMinigame } from "../minigames/GrinchHeistMinigame";
 
 const MINIGAME_CHANCE = 0.4;
 const MINIGAME_DELAY_SECONDS = 5 * 60;
@@ -119,7 +120,8 @@ export class Tree implements ISlashCommand {
     ...SantaPresentMinigame.buttons,
     ...HotCocoaMinigame.buttons,
     ...GiftUnwrappingMinigame.buttons,
-    ...SnowballFightMinigame.buttons
+    ...SnowballFightMinigame.buttons,
+    ...GrinchHeistMinigame.buttons
   ];
 }
 

--- a/src/commands/Tree.ts
+++ b/src/commands/Tree.ts
@@ -125,7 +125,7 @@ export class Tree implements ISlashCommand {
   ];
 }
 
-export function transitionToDefaultTreeView(ctx: ButtonContext, delay = 3000) {
+export function transitionToDefaultTreeView(ctx: ButtonContext, delay = 6000) {
   if (!ctx.game) throw new Error("Game data missing.");
   ctx.timeouts.set(
     ctx.interaction.message.id,

--- a/src/minigames/GrinchHeistMinigame.ts
+++ b/src/minigames/GrinchHeistMinigame.ts
@@ -1,6 +1,6 @@
 import { ButtonContext, EmbedBuilder, MessageBuilder, ActionRowBuilder, Button, ButtonBuilder } from "interactions.ts";
 import { shuffleArray } from "../util/helpers/arrayHelper";
-import { buildTreeDisplayMessage, transitionToDefaultTreeView } from "../commands/Tree";
+import { transitionToDefaultTreeView } from "../commands/Tree";
 import { Minigame, MinigameConfig } from "../util/types/minigame/MinigameType";
 
 const GRINCH_HEIST_MINIGAME_MAX_DURATION = 10 * 1000;
@@ -21,7 +21,9 @@ export class GrinchHeistMinigame implements Minigame {
       .setTitle("Grinch Heist!")
       .setDescription("Click the tree to save it from the Grinch. Avoid the Grinch!")
       .setImage(this.grinchImages[Math.floor(Math.random() * this.grinchImages.length)])
-      .setFooter({ text: "Hurry! Save your tree before it's too late! Enjoy unlimited levels, fun minigames and more via the shop!" });
+      .setFooter({
+        text: "You have just discovered a premium feature! Subscribe in the [store](https://discord.com/application-directory/1050722873569968128/store) to enjoy more fun minigames!"
+      });
 
     const buttons = [
       await ctx.manager.components.createInstance("minigame.grinchheist.tree"),
@@ -39,7 +41,7 @@ export class GrinchHeistMinigame implements Minigame {
     await ctx.reply(message);
 
     const timeoutId = setTimeout(async () => {
-      ctx.timeouts.delete(ctx.interaction.message.id);
+      ctx.timeouts.delete(ctx.interaction?.message?.id ?? "broken");
       await GrinchHeistMinigame.handleGrinchButton(ctx);
     }, GRINCH_HEIST_MINIGAME_MAX_DURATION);
 
@@ -49,7 +51,7 @@ export class GrinchHeistMinigame implements Minigame {
   private static async handleGrinchButton(ctx: ButtonContext): Promise<void> {
     const timeout = ctx.timeouts.get(ctx.interaction.message.id);
     if (timeout) clearTimeout(timeout);
-    ctx.timeouts.delete(ctx.interaction.message.id);
+    ctx.timeouts.delete(ctx.interaction?.message?.id ?? "broken");
 
     if (!ctx.game) throw new Error("Game data missing.");
     const loss = Math.min(5, Math.floor(ctx.game.size * 0.1));
@@ -72,7 +74,7 @@ export class GrinchHeistMinigame implements Minigame {
       async (ctx: ButtonContext): Promise<void> => {
         const timeout = ctx.timeouts.get(ctx.interaction.message.id);
         if (timeout) clearTimeout(timeout);
-        ctx.timeouts.delete(ctx.interaction.message.id);
+        ctx.timeouts.delete(ctx.interaction?.message?.id ?? "broken");
 
         if (!ctx.game) throw new Error("Game data missing.");
         ctx.game.size++;

--- a/src/minigames/GrinchHeistMinigame.ts
+++ b/src/minigames/GrinchHeistMinigame.ts
@@ -1,0 +1,106 @@
+import { ButtonContext, EmbedBuilder, MessageBuilder, ActionRowBuilder, Button, ButtonBuilder } from "interactions.ts";
+import { shuffleArray } from "../util/helpers/arrayHelper";
+import { buildTreeDisplayMessage, transitionToDefaultTreeView } from "../commands/Tree";
+import { Minigame, MinigameConfig } from "../util/types/minigame/MinigameType";
+
+const GRINCH_HEIST_MINIGAME_MAX_DURATION = 10 * 1000;
+
+export class GrinchHeistMinigame implements Minigame {
+  config: MinigameConfig = {
+    premiumGuildOnly: false
+  };
+
+  private grinchImages = [
+    "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/grinch-heist/grinch-heist-1.jpg",
+    "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/grinch-heist/grinch-heist-2.jpg",
+    "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/grinch-heist/grinch-heist-3.jpg"
+  ];
+
+  async start(ctx: ButtonContext): Promise<void> {
+    const embed = new EmbedBuilder()
+      .setTitle("Grinch Heist!")
+      .setDescription("Click the tree to save it from the Grinch. Avoid the Grinch!")
+      .setImage(this.grinchImages[Math.floor(Math.random() * this.grinchImages.length)])
+      .setFooter({ text: "Hurry! Save your tree before it's too late! Enjoy unlimited levels, fun minigames and more via the shop!" });
+
+    const buttons = [
+      await ctx.manager.components.createInstance("minigame.grinchheist.tree"),
+      await ctx.manager.components.createInstance("minigame.grinchheist.grinch-1"),
+      await ctx.manager.components.createInstance("minigame.grinchheist.grinch-2"),
+      await ctx.manager.components.createInstance("minigame.grinchheist.grinch-3")
+    ];
+
+    shuffleArray(buttons);
+
+    const message = new MessageBuilder().addComponents(new ActionRowBuilder().addComponents(...buttons));
+
+    message.addEmbed(embed);
+
+    await ctx.reply(message);
+
+    const timeoutId = setTimeout(async () => {
+      ctx.timeouts.delete(ctx.interaction.message.id);
+      await GrinchHeistMinigame.handleGrinchButton(ctx);
+    }, GRINCH_HEIST_MINIGAME_MAX_DURATION);
+
+    ctx.timeouts.set(ctx.interaction.message.id, timeoutId);
+  }
+
+  private static async handleGrinchButton(ctx: ButtonContext): Promise<void> {
+    const timeout = ctx.timeouts.get(ctx.interaction.message.id);
+    if (timeout) clearTimeout(timeout);
+    ctx.timeouts.delete(ctx.interaction.message.id);
+
+    if (!ctx.game) throw new Error("Game data missing.");
+    const loss = Math.min(5, Math.floor(ctx.game.size * 0.1));
+    ctx.game.size = Math.max(0, ctx.game.size - loss);
+    await ctx.game.save();
+
+    const embed = new EmbedBuilder()
+      .setTitle(ctx.game.name)
+      .setDescription(`The Grinch stole part of your tree! You lost ${loss}ft.`);
+
+    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+
+    transitionToDefaultTreeView(ctx);
+  }
+
+  public static buttons = [
+    new Button(
+      "minigame.grinchheist.tree",
+      new ButtonBuilder().setEmoji({ name: "🎄" }).setStyle(1),
+      async (ctx: ButtonContext): Promise<void> => {
+        const timeout = ctx.timeouts.get(ctx.interaction.message.id);
+        if (timeout) clearTimeout(timeout);
+        ctx.timeouts.delete(ctx.interaction.message.id);
+
+        if (!ctx.game) throw new Error("Game data missing.");
+        ctx.game.size++;
+        await ctx.game.save();
+
+        const embed = new EmbedBuilder()
+          .setTitle(ctx.game.name)
+          .setDescription("You saved the tree! Your tree grew taller!");
+
+        ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+
+        transitionToDefaultTreeView(ctx);
+      }
+    ),
+    new Button(
+      "minigame.grinchheist.grinch-1",
+      new ButtonBuilder().setEmoji({ name: "😈" }).setStyle(4),
+      GrinchHeistMinigame.handleGrinchButton
+    ),
+    new Button(
+      "minigame.grinchheist.grinch-2",
+      new ButtonBuilder().setEmoji({ name: "😈" }).setStyle(4),
+      GrinchHeistMinigame.handleGrinchButton
+    ),
+    new Button(
+      "minigame.grinchheist.grinch-3",
+      new ButtonBuilder().setEmoji({ name: "😈" }).setStyle(4),
+      GrinchHeistMinigame.handleGrinchButton
+    )
+  ];
+}

--- a/src/minigames/MinigameFactory.ts
+++ b/src/minigames/MinigameFactory.ts
@@ -1,17 +1,17 @@
-// src/minigames/MinigameFactory.ts
-
 import { ButtonContext } from "interactions.ts";
 import { SantaPresentMinigame } from "./SantaPresentMinigame";
 import { Minigame } from "../util/types/minigame/MinigameType";
 import { HotCocoaMinigame } from "./HotCocoaMinigame";
 import { GiftUnwrappingMinigame } from "./GiftUnwrappingMinigame";
 import { SnowballFightMinigame } from "./SnowballFightMinigame";
+import { GrinchHeistMinigame } from "./GrinchHeistMinigame";
 
 const minigames: Minigame[] = [
   new SantaPresentMinigame(),
   new HotCocoaMinigame(),
   new GiftUnwrappingMinigame(),
-  new SnowballFightMinigame()
+  new SnowballFightMinigame(),
+  new GrinchHeistMinigame()
 ];
 
 export async function startRandomMinigame(ctx: ButtonContext): Promise<boolean> {


### PR DESCRIPTION
Fixes #64

Add Grinch Heist minigame to the project.

* Create `GrinchHeistMinigame` class in `src/minigames/GrinchHeistMinigame.ts`
  - Add `start` method to initialize the minigame
  - Add buttons for the grinch and tree
  - Implement logic for losing and gaining tree length
  - Add images for the grinch and tree
  - Set the minigame as non-premium
  - Upsell premium in the footer text
  - Unify the logic for the grinch buttons into one function
  - Handle timeout for the grinch button

* Modify `src/minigames/MinigameFactory.ts`
  - Import `GrinchHeistMinigame` class
  - Add `GrinchHeistMinigame` to the list of minigames

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GewoonJaap/grow-a-christmas-tree/issues/64?shareId=7c77c4e5-bb07-4251-801f-9c91b6353e1d).