### PR TITLE
Add new minigames with multiple stages and randomized buttons

### DIFF
--- a/src/commands/Tree.ts
+++ b/src/commands/Tree.ts
@@ -20,6 +20,9 @@ import { HotCocoaMinigame } from "../minigames/HotCocoaMinigame";
 import { GiftUnwrappingMinigame } from "../minigames/GiftUnwrappingMinigame";
 import { SnowballFightMinigame } from "../minigames/SnowballFightMinigame";
 import { GrinchHeistMinigame } from "../minigames/GrinchHeistMinigame";
+import { HolidayCookieCountdownMinigame } from "../minigames/HolidayCookieCountdownMinigame";
+import { TinselTwisterMinigame } from "../minigames/TinselTwisterMinigame";
+import { CarolingChoirMinigame } from "../minigames/CarolingChoirMinigame";
 
 const MINIGAME_CHANCE = 0.4;
 const MINIGAME_DELAY_SECONDS = 5 * 60;
@@ -121,7 +124,10 @@ export class Tree implements ISlashCommand {
     ...HotCocoaMinigame.buttons,
     ...GiftUnwrappingMinigame.buttons,
     ...SnowballFightMinigame.buttons,
-    ...GrinchHeistMinigame.buttons
+    ...GrinchHeistMinigame.buttons,
+    ...HolidayCookieCountdownMinigame.buttons,
+    ...TinselTwisterMinigame.buttons,
+    ...CarolingChoirMinigame.buttons
   ];
 }
 

--- a/src/minigames/CarolingChoirMinigame.ts
+++ b/src/minigames/CarolingChoirMinigame.ts
@@ -1,0 +1,106 @@
+import { ButtonContext, EmbedBuilder, MessageBuilder, ActionRowBuilder, Button, ButtonBuilder } from "interactions.ts";
+import { shuffleArray } from "../util/helpers/arrayHelper";
+import { buildTreeDisplayMessage, transitionToDefaultTreeView } from "../commands/Tree";
+import { Minigame, MinigameConfig } from "../util/types/minigame/MinigameType";
+
+const CAROLING_CHOIR_MINIGAME_MAX_DURATION = 10 * 1000;
+
+export class CarolingChoirMinigame implements Minigame {
+  config: MinigameConfig = {
+    premiumGuildOnly: false
+  };
+
+  private choirImages = [
+    "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/caroling-choir/caroling-choir-1.png",
+    "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/caroling-choir/caroling-choir-2.png"
+  ];
+
+  private currentStage = 0;
+  private maxStages = 3;
+
+  async start(ctx: ButtonContext): Promise<void> {
+    this.currentStage = 0;
+    await this.nextStage(ctx);
+  }
+
+  private async nextStage(ctx: ButtonContext): Promise<void> {
+    if (this.currentStage >= this.maxStages) {
+      await this.completeMinigame(ctx);
+      return;
+    }
+
+    const embed = new EmbedBuilder()
+      .setTitle("Caroling Choir!")
+      .setDescription(`Stage ${this.currentStage + 1}: Click the 🎶 to lead the carolers. Follow the correct sequence!`)
+      .setImage(this.choirImages[Math.floor(Math.random() * this.choirImages.length)])
+      .setFooter({ text: "Lead the carolers in a festive song!" });
+
+    const buttons = [
+      await ctx.manager.components.createInstance("minigame.carolingchoir.note"),
+      await ctx.manager.components.createInstance("minigame.carolingchoir.wrongnote")
+    ];
+
+    shuffleArray(buttons);
+
+    const message = new MessageBuilder().addComponents(new ActionRowBuilder().addComponents(...buttons));
+
+    message.addEmbed(embed);
+
+    await ctx.reply(message);
+
+    const timeoutId = setTimeout(async () => {
+      ctx.timeouts.delete(ctx.interaction.message.id);
+      await ctx.edit(await buildTreeDisplayMessage(ctx));
+    }, CAROLING_CHOIR_MINIGAME_MAX_DURATION);
+
+    ctx.timeouts.set(ctx.interaction.message.id, timeoutId);
+  }
+
+  private async completeMinigame(ctx: ButtonContext): Promise<void> {
+    if (!ctx.game) throw new Error("Game data missing.");
+    ctx.game.size++;
+    await ctx.game.save();
+
+    const embed = new EmbedBuilder()
+      .setTitle(ctx.game.name)
+      .setDescription("You led the carolers perfectly! Your tree has grown!");
+
+    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+
+    transitionToDefaultTreeView(ctx);
+  }
+
+  public static buttons = [
+    new Button(
+      "minigame.carolingchoir.note",
+      new ButtonBuilder().setEmoji({ name: "🎶" }).setStyle(1),
+      async (ctx: ButtonContext): Promise<void> => {
+        const timeout = ctx.timeouts.get(ctx.interaction.message.id);
+        if (timeout) clearTimeout(timeout);
+        ctx.timeouts.delete(ctx.interaction.message.id);
+
+        const minigame = new CarolingChoirMinigame();
+        minigame.currentStage = ctx.state?.currentStage ?? 0;
+        minigame.currentStage++;
+        await minigame.nextStage(ctx);
+      }
+    ),
+    new Button(
+      "minigame.carolingchoir.wrongnote",
+      new ButtonBuilder().setEmoji({ name: "❌" }).setStyle(4),
+      async (ctx: ButtonContext): Promise<void> => {
+        const timeout = ctx.timeouts.get(ctx.interaction.message.id);
+        if (timeout) clearTimeout(timeout);
+        ctx.timeouts.delete(ctx.interaction.message.id);
+        if (!ctx.game) throw new Error("Game data missing.");
+        const embed = new EmbedBuilder()
+          .setTitle(ctx.game.name)
+          .setDescription("You hit a wrong note. Better luck next time!");
+
+        ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+
+        transitionToDefaultTreeView(ctx);
+      }
+    )
+  ];
+}

--- a/src/minigames/CarolingChoirMinigame.ts
+++ b/src/minigames/CarolingChoirMinigame.ts
@@ -5,6 +5,10 @@ import { Minigame, MinigameConfig } from "../util/types/minigame/MinigameType";
 
 const CAROLING_CHOIR_MINIGAME_MAX_DURATION = 10 * 1000;
 
+type CarolingChoirButtonState = {
+  currentStage: number;
+};
+
 export class CarolingChoirMinigame implements Minigame {
   config: MinigameConfig = {
     premiumGuildOnly: false
@@ -15,48 +19,46 @@ export class CarolingChoirMinigame implements Minigame {
     "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/caroling-choir/caroling-choir-2.png"
   ];
 
-  private currentStage = 0;
   private maxStages = 3;
 
   async start(ctx: ButtonContext): Promise<void> {
-    this.currentStage = 0;
-    await this.nextStage(ctx);
+    await this.nextStage(ctx, 0);
   }
 
-  private async nextStage(ctx: ButtonContext): Promise<void> {
-    if (this.currentStage >= this.maxStages) {
+  private async nextStage(ctx: ButtonContext<CarolingChoirButtonState>, currentStage: number): Promise<void> {
+    if (currentStage >= this.maxStages) {
       await this.completeMinigame(ctx);
       return;
     }
 
     const embed = new EmbedBuilder()
       .setTitle("Caroling Choir!")
-      .setDescription(`Stage ${this.currentStage + 1}: Click the 🎶 to lead the carolers. Follow the correct sequence!`)
+      .setDescription(`Stage ${currentStage + 1}: Click the 🎶 to lead the carolers. Follow the correct sequence!`)
       .setImage(this.choirImages[Math.floor(Math.random() * this.choirImages.length)])
       .setFooter({ text: "Lead the carolers in a festive song!" });
 
     const buttons = [
-      await ctx.manager.components.createInstance("minigame.carolingchoir.note"),
-      await ctx.manager.components.createInstance("minigame.carolingchoir.wrongnote")
+      await ctx.manager.components.createInstance("minigame.carolingchoir.note", { currentStage }),
+      await ctx.manager.components.createInstance("minigame.carolingchoir.wrongnote", { currentStage })
     ];
 
     shuffleArray(buttons);
 
-    const message = new MessageBuilder().addComponents(new ActionRowBuilder().addComponents(...buttons));
-
-    message.addEmbed(embed);
+    const message = new MessageBuilder()
+      .addEmbed(embed)
+      .addComponents(new ActionRowBuilder().addComponents(...buttons));
 
     await ctx.reply(message);
 
     const timeoutId = setTimeout(async () => {
       ctx.timeouts.delete(ctx.interaction.message.id);
-      await ctx.edit(await buildTreeDisplayMessage(ctx));
+      await ctx.edit(await buildTreeDisplayMessage(ctx as ButtonContext));
     }, CAROLING_CHOIR_MINIGAME_MAX_DURATION);
 
     ctx.timeouts.set(ctx.interaction.message.id, timeoutId);
   }
 
-  private async completeMinigame(ctx: ButtonContext): Promise<void> {
+  private async completeMinigame(ctx: ButtonContext<CarolingChoirButtonState>): Promise<void> {
     if (!ctx.game) throw new Error("Game data missing.");
     ctx.game.size++;
     await ctx.game.save();
@@ -65,41 +67,41 @@ export class CarolingChoirMinigame implements Minigame {
       .setTitle(ctx.game.name)
       .setDescription("You led the carolers perfectly! Your tree has grown!");
 
-    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
 
-    transitionToDefaultTreeView(ctx);
+    transitionToDefaultTreeView(ctx as ButtonContext);
   }
 
   public static buttons = [
     new Button(
       "minigame.carolingchoir.note",
       new ButtonBuilder().setEmoji({ name: "🎶" }).setStyle(1),
-      async (ctx: ButtonContext): Promise<void> => {
+      async (ctx: ButtonContext<CarolingChoirButtonState>): Promise<void> => {
         const timeout = ctx.timeouts.get(ctx.interaction.message.id);
         if (timeout) clearTimeout(timeout);
         ctx.timeouts.delete(ctx.interaction.message.id);
 
+        const currentStage = ctx.state?.currentStage ?? 0;
         const minigame = new CarolingChoirMinigame();
-        minigame.currentStage = ctx.state?.currentStage ?? 0;
-        minigame.currentStage++;
-        await minigame.nextStage(ctx);
+        await minigame.nextStage(ctx, currentStage + 1);
       }
     ),
     new Button(
       "minigame.carolingchoir.wrongnote",
       new ButtonBuilder().setEmoji({ name: "❌" }).setStyle(4),
-      async (ctx: ButtonContext): Promise<void> => {
+      async (ctx: ButtonContext<CarolingChoirButtonState>): Promise<void> => {
         const timeout = ctx.timeouts.get(ctx.interaction.message.id);
         if (timeout) clearTimeout(timeout);
         ctx.timeouts.delete(ctx.interaction.message.id);
+
         if (!ctx.game) throw new Error("Game data missing.");
         const embed = new EmbedBuilder()
           .setTitle(ctx.game.name)
           .setDescription("You hit a wrong note. Better luck next time!");
 
-        ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+        await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
 
-        transitionToDefaultTreeView(ctx);
+        transitionToDefaultTreeView(ctx as ButtonContext);
       }
     )
   ];

--- a/src/minigames/CarolingChoirMinigame.ts
+++ b/src/minigames/CarolingChoirMinigame.ts
@@ -2,6 +2,7 @@ import { ButtonContext, EmbedBuilder, MessageBuilder, ActionRowBuilder, Button, 
 import { shuffleArray } from "../util/helpers/arrayHelper";
 import { buildTreeDisplayMessage, transitionToDefaultTreeView } from "../commands/Tree";
 import { Minigame, MinigameConfig } from "../util/types/minigame/MinigameType";
+import { getPremiumUpsellMessage } from "./MinigameFactory";
 
 const CAROLING_CHOIR_MINIGAME_MAX_DURATION = 10 * 1000;
 
@@ -15,8 +16,8 @@ export class CarolingChoirMinigame implements Minigame {
   };
 
   private choirImages = [
-    "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/caroling-choir/caroling-choir-1.png",
-    "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/caroling-choir/caroling-choir-2.png"
+    "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/caroling-choir/caroling-choir-1.jpg",
+    "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/caroling-choir/caroling-choir-2.jpg"
   ];
 
   private maxStages = 3;
@@ -33,13 +34,21 @@ export class CarolingChoirMinigame implements Minigame {
 
     const embed = new EmbedBuilder()
       .setTitle("Caroling Choir!")
-      .setDescription(`Stage ${currentStage + 1}: Click the 🎶 to lead the carolers. Follow the correct sequence!`)
+      .setDescription(
+        `Stage ${
+          currentStage + 1
+        }: Click the 🎶 to lead the carolers. Follow the correct sequence!${getPremiumUpsellMessage(
+          ctx as ButtonContext
+        )}`
+      )
       .setImage(this.choirImages[Math.floor(Math.random() * this.choirImages.length)])
       .setFooter({ text: "Lead the carolers in a festive song!" });
 
     const buttons = [
       await ctx.manager.components.createInstance("minigame.carolingchoir.note", { currentStage }),
-      await ctx.manager.components.createInstance("minigame.carolingchoir.wrongnote", { currentStage })
+      await ctx.manager.components.createInstance("minigame.carolingchoir.wrongnote-1", { currentStage }),
+      await ctx.manager.components.createInstance("minigame.carolingchoir.wrongnote-2", { currentStage }),
+      await ctx.manager.components.createInstance("minigame.carolingchoir.wrongnote-3", { currentStage })
     ];
 
     shuffleArray(buttons);
@@ -65,7 +74,32 @@ export class CarolingChoirMinigame implements Minigame {
 
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
-      .setDescription("You led the carolers perfectly! Your tree has grown!");
+      .setDescription("You led the carolers perfectly! Your tree has grown 1ft!");
+
+    await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+
+    transitionToDefaultTreeView(ctx as ButtonContext);
+  }
+
+  private static async handleNoteButton(ctx: ButtonContext<CarolingChoirButtonState>): Promise<void> {
+    const timeout = ctx.timeouts.get(ctx.interaction.message.id);
+    if (timeout) clearTimeout(timeout);
+    ctx.timeouts.delete(ctx.interaction.message.id);
+
+    const currentStage = ctx.state?.currentStage ?? 0;
+    const minigame = new CarolingChoirMinigame();
+    await minigame.nextStage(ctx, currentStage + 1);
+  }
+
+  private static async handleWrongNoteButton(ctx: ButtonContext<CarolingChoirButtonState>): Promise<void> {
+    const timeout = ctx.timeouts.get(ctx.interaction.message.id);
+    if (timeout) clearTimeout(timeout);
+    ctx.timeouts.delete(ctx.interaction.message.id);
+
+    if (!ctx.game) throw new Error("Game data missing.");
+    const embed = new EmbedBuilder()
+      .setTitle(ctx.game.name)
+      .setDescription("You hit a wrong note. Better luck next time!");
 
     await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
 
@@ -76,33 +110,22 @@ export class CarolingChoirMinigame implements Minigame {
     new Button(
       "minigame.carolingchoir.note",
       new ButtonBuilder().setEmoji({ name: "🎶" }).setStyle(1),
-      async (ctx: ButtonContext<CarolingChoirButtonState>): Promise<void> => {
-        const timeout = ctx.timeouts.get(ctx.interaction.message.id);
-        if (timeout) clearTimeout(timeout);
-        ctx.timeouts.delete(ctx.interaction.message.id);
-
-        const currentStage = ctx.state?.currentStage ?? 0;
-        const minigame = new CarolingChoirMinigame();
-        await minigame.nextStage(ctx, currentStage + 1);
-      }
+      CarolingChoirMinigame.handleNoteButton
     ),
     new Button(
-      "minigame.carolingchoir.wrongnote",
-      new ButtonBuilder().setEmoji({ name: "❌" }).setStyle(4),
-      async (ctx: ButtonContext<CarolingChoirButtonState>): Promise<void> => {
-        const timeout = ctx.timeouts.get(ctx.interaction.message.id);
-        if (timeout) clearTimeout(timeout);
-        ctx.timeouts.delete(ctx.interaction.message.id);
-
-        if (!ctx.game) throw new Error("Game data missing.");
-        const embed = new EmbedBuilder()
-          .setTitle(ctx.game.name)
-          .setDescription("You hit a wrong note. Better luck next time!");
-
-        await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
-
-        transitionToDefaultTreeView(ctx as ButtonContext);
-      }
+      "minigame.carolingchoir.wrongnote-1",
+      new ButtonBuilder().setEmoji({ name: "🪘" }).setStyle(4),
+      CarolingChoirMinigame.handleWrongNoteButton
+    ),
+    new Button(
+      "minigame.carolingchoir.wrongnote-2",
+      new ButtonBuilder().setEmoji({ name: "🐈" }).setStyle(4),
+      CarolingChoirMinigame.handleWrongNoteButton
+    ),
+    new Button(
+      "minigame.carolingchoir.wrongnote-3",
+      new ButtonBuilder().setEmoji({ name: "😼" }).setStyle(4),
+      CarolingChoirMinigame.handleWrongNoteButton
     )
   ];
 }

--- a/src/minigames/GiftUnwrappingMinigame.ts
+++ b/src/minigames/GiftUnwrappingMinigame.ts
@@ -61,7 +61,7 @@ export class GiftUnwrappingMinigame implements Minigame {
       message = "You unwrapped a gift and found a magical watering can! Your tree can be watered again.";
     } else if (randomOutcome < 0.66) {
       ctx.game.size += 2;
-      message = "You unwrapped a gift and found a special fertilizer! Your tree grew extra tall.";
+      message = "You unwrapped a gift and found a special fertilizer! Your tree grew 2ft tall.";
     } else {
       message = "You unwrapped a gift but found nothing special inside.";
     }
@@ -107,12 +107,12 @@ export class GiftUnwrappingMinigame implements Minigame {
     ),
     new Button(
       "minigame.giftunwrapping.emptybox-2",
-      new ButtonBuilder().setEmoji({ name: "📦" }).setStyle(4),
+      new ButtonBuilder().setEmoji({ name: "🧃" }).setStyle(4),
       GiftUnwrappingMinigame.handleEmptyBoxButton
     ),
     new Button(
       "minigame.giftunwrapping.emptybox-3",
-      new ButtonBuilder().setEmoji({ name: "📦" }).setStyle(4),
+      new ButtonBuilder().setEmoji({ name: "🧰" }).setStyle(4),
       GiftUnwrappingMinigame.handleEmptyBoxButton
     )
   ];

--- a/src/minigames/GrinchHeistMinigame.ts
+++ b/src/minigames/GrinchHeistMinigame.ts
@@ -90,7 +90,7 @@ export class GrinchHeistMinigame implements Minigame {
 
         const embed = new EmbedBuilder()
           .setTitle(ctx.game.name)
-          .setDescription("You saved the tree! Your tree grew taller!")
+          .setDescription("You saved the tree! Your tree grew 1ft taller!")
           .setImage(
             "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/grinch-heist/grinch-tree-saved-1.jpg"
           );

--- a/src/minigames/HolidayCookieCountdownMinigame.ts
+++ b/src/minigames/HolidayCookieCountdownMinigame.ts
@@ -1,7 +1,8 @@
 import { ButtonContext, EmbedBuilder, MessageBuilder, ActionRowBuilder, Button, ButtonBuilder } from "interactions.ts";
 import { shuffleArray } from "../util/helpers/arrayHelper";
-import { buildTreeDisplayMessage, transitionToDefaultTreeView } from "../commands/Tree";
+import { transitionToDefaultTreeView } from "../commands/Tree";
 import { Minigame, MinigameConfig } from "../util/types/minigame/MinigameType";
+import { getPremiumUpsellMessage } from "./MinigameFactory";
 
 const HOLIDAY_COOKIE_COUNTDOWN_MINIGAME_MAX_DURATION = 10 * 1000;
 
@@ -15,8 +16,9 @@ export class HolidayCookieCountdownMinigame implements Minigame {
   };
 
   private cookieImages = [
-    "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/holiday-cookie-countdown/holiday-cookie-countdown-1.png",
-    "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/holiday-cookie-countdown/holiday-cookie-countdown-2.png"
+    "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/holiday-cookie-countdown/holiday-cookie-countdown-1.jpg",
+    "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/holiday-cookie-countdown/holiday-cookie-countdown-2.jpg",
+    "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/holiday-cookie-countdown/holiday-cookie-countdown-3.jpg"
   ];
 
   private maxStages = 3;
@@ -33,13 +35,21 @@ export class HolidayCookieCountdownMinigame implements Minigame {
 
     const embed = new EmbedBuilder()
       .setTitle("Holiday Cookie Countdown!")
-      .setDescription(`Stage ${currentStage + 1}: Click the 🍪 button as cookies appear. Each stage adds more cookies!`)
+      .setDescription(
+        `Stage ${
+          currentStage + 1
+        }: Click the 🍪 button as cookies appear. Each stage adds more cookies!${getPremiumUpsellMessage(
+          ctx as ButtonContext
+        )}`
+      )
       .setImage(this.cookieImages[Math.floor(Math.random() * this.cookieImages.length)])
       .setFooter({ text: "Hurry! You have limited time!" });
 
     const buttons = [
       await ctx.manager.components.createInstance("minigame.holidaycookiecountdown.cookie", { currentStage }),
-      await ctx.manager.components.createInstance("minigame.holidaycookiecountdown.emptyplate", { currentStage })
+      await ctx.manager.components.createInstance("minigame.holidaycookiecountdown.emptyplate-1", { currentStage }),
+      await ctx.manager.components.createInstance("minigame.holidaycookiecountdown.emptyplate-2", { currentStage }),
+      await ctx.manager.components.createInstance("minigame.holidaycookiecountdown.emptyplate-3", { currentStage })
     ];
 
     shuffleArray(buttons);
@@ -52,7 +62,7 @@ export class HolidayCookieCountdownMinigame implements Minigame {
 
     const timeoutId = setTimeout(async () => {
       ctx.timeouts.delete(ctx.interaction.message.id);
-      await ctx.edit(await buildTreeDisplayMessage(ctx as ButtonContext));
+      await HolidayCookieCountdownMinigame.handleEmptyPlateButton(ctx, true);
     }, HOLIDAY_COOKIE_COUNTDOWN_MINIGAME_MAX_DURATION);
 
     ctx.timeouts.set(ctx.interaction.message.id, timeoutId);
@@ -65,9 +75,41 @@ export class HolidayCookieCountdownMinigame implements Minigame {
 
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
-      .setDescription("You completed the Holiday Cookie Countdown! Your tree has grown!");
+      .setDescription("You collected all the cookies! Your tree has grown 1ft!");
 
     await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+
+    transitionToDefaultTreeView(ctx as ButtonContext);
+  }
+
+  private static async handleCookieButton(ctx: ButtonContext<CookieCountdownButtonState>): Promise<void> {
+    const timeout = ctx.timeouts.get(ctx.interaction.message.id);
+    if (timeout) clearTimeout(timeout);
+    ctx.timeouts.delete(ctx.interaction.message.id);
+
+    const currentStage = ctx.state?.currentStage ?? 0;
+    const minigame = new HolidayCookieCountdownMinigame();
+    await minigame.nextStage(ctx, currentStage + 1);
+  }
+
+  private static async handleEmptyPlateButton(
+    ctx: ButtonContext<CookieCountdownButtonState>,
+    isTimeout = false
+  ): Promise<void> {
+    const timeout = ctx.timeouts.get(ctx.interaction.message.id);
+    if (timeout) clearTimeout(timeout);
+    ctx.timeouts.delete(ctx.interaction.message.id);
+
+    if (!ctx.game) throw new Error("Game data missing.");
+    const embed = new EmbedBuilder()
+      .setTitle(ctx.game.name)
+      .setDescription("You missed the cookie. Better luck next time!");
+
+    if (isTimeout) {
+      await ctx.edit(new MessageBuilder().addEmbed(embed).setComponents([]));
+    } else {
+      await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    }
 
     transitionToDefaultTreeView(ctx as ButtonContext);
   }
@@ -76,33 +118,22 @@ export class HolidayCookieCountdownMinigame implements Minigame {
     new Button(
       "minigame.holidaycookiecountdown.cookie",
       new ButtonBuilder().setEmoji({ name: "🍪" }).setStyle(1),
-      async (ctx: ButtonContext<CookieCountdownButtonState>): Promise<void> => {
-        const timeout = ctx.timeouts.get(ctx.interaction.message.id);
-        if (timeout) clearTimeout(timeout);
-        ctx.timeouts.delete(ctx.interaction.message.id);
-
-        const currentStage = ctx.state?.currentStage ?? 0;
-        const minigame = new HolidayCookieCountdownMinigame();
-        await minigame.nextStage(ctx, currentStage + 1);
-      }
+      HolidayCookieCountdownMinigame.handleCookieButton
     ),
     new Button(
-      "minigame.holidaycookiecountdown.emptyplate",
+      "minigame.holidaycookiecountdown.emptyplate-1",
       new ButtonBuilder().setEmoji({ name: "❌" }).setStyle(4),
-      async (ctx: ButtonContext<CookieCountdownButtonState>): Promise<void> => {
-        const timeout = ctx.timeouts.get(ctx.interaction.message.id);
-        if (timeout) clearTimeout(timeout);
-        ctx.timeouts.delete(ctx.interaction.message.id);
-
-        if (!ctx.game) throw new Error("Game data missing.");
-        const embed = new EmbedBuilder()
-          .setTitle(ctx.game.name)
-          .setDescription("You clicked the empty plate. Better luck next time!");
-
-        await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
-
-        transitionToDefaultTreeView(ctx as ButtonContext);
-      }
+      HolidayCookieCountdownMinigame.handleEmptyPlateButton
+    ),
+    new Button(
+      "minigame.holidaycookiecountdown.emptyplate-2",
+      new ButtonBuilder().setEmoji({ name: "🍽️" }).setStyle(4),
+      HolidayCookieCountdownMinigame.handleEmptyPlateButton
+    ),
+    new Button(
+      "minigame.holidaycookiecountdown.emptyplate-3",
+      new ButtonBuilder().setEmoji({ name: "🥠" }).setStyle(4),
+      HolidayCookieCountdownMinigame.handleEmptyPlateButton
     )
   ];
 }

--- a/src/minigames/HolidayCookieCountdownMinigame.ts
+++ b/src/minigames/HolidayCookieCountdownMinigame.ts
@@ -5,6 +5,10 @@ import { Minigame, MinigameConfig } from "../util/types/minigame/MinigameType";
 
 const HOLIDAY_COOKIE_COUNTDOWN_MINIGAME_MAX_DURATION = 10 * 1000;
 
+type CookieCountdownButtonState = {
+  currentStage: number;
+};
+
 export class HolidayCookieCountdownMinigame implements Minigame {
   config: MinigameConfig = {
     premiumGuildOnly: false
@@ -15,48 +19,46 @@ export class HolidayCookieCountdownMinigame implements Minigame {
     "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/holiday-cookie-countdown/holiday-cookie-countdown-2.png"
   ];
 
-  private currentStage = 0;
   private maxStages = 3;
 
   async start(ctx: ButtonContext): Promise<void> {
-    this.currentStage = 0;
-    await this.nextStage(ctx);
+    await this.nextStage(ctx, 0);
   }
 
-  private async nextStage(ctx: ButtonContext): Promise<void> {
-    if (this.currentStage >= this.maxStages) {
+  private async nextStage(ctx: ButtonContext<CookieCountdownButtonState>, currentStage: number): Promise<void> {
+    if (currentStage >= this.maxStages) {
       await this.completeMinigame(ctx);
       return;
     }
 
     const embed = new EmbedBuilder()
       .setTitle("Holiday Cookie Countdown!")
-      .setDescription(`Stage ${this.currentStage + 1}: Click the 🍪 button as cookies appear. Each stage adds more cookies!`)
+      .setDescription(`Stage ${currentStage + 1}: Click the 🍪 button as cookies appear. Each stage adds more cookies!`)
       .setImage(this.cookieImages[Math.floor(Math.random() * this.cookieImages.length)])
       .setFooter({ text: "Hurry! You have limited time!" });
 
     const buttons = [
-      await ctx.manager.components.createInstance("minigame.holidaycookiecountdown.cookie"),
-      await ctx.manager.components.createInstance("minigame.holidaycookiecountdown.emptyplate")
+      await ctx.manager.components.createInstance("minigame.holidaycookiecountdown.cookie", { currentStage }),
+      await ctx.manager.components.createInstance("minigame.holidaycookiecountdown.emptyplate", { currentStage })
     ];
 
     shuffleArray(buttons);
 
-    const message = new MessageBuilder().addComponents(new ActionRowBuilder().addComponents(...buttons));
-
-    message.addEmbed(embed);
+    const message = new MessageBuilder()
+      .addEmbed(embed)
+      .addComponents(new ActionRowBuilder().addComponents(...buttons));
 
     await ctx.reply(message);
 
     const timeoutId = setTimeout(async () => {
       ctx.timeouts.delete(ctx.interaction.message.id);
-      await ctx.edit(await buildTreeDisplayMessage(ctx));
+      await ctx.edit(await buildTreeDisplayMessage(ctx as ButtonContext));
     }, HOLIDAY_COOKIE_COUNTDOWN_MINIGAME_MAX_DURATION);
 
     ctx.timeouts.set(ctx.interaction.message.id, timeoutId);
   }
 
-  private async completeMinigame(ctx: ButtonContext): Promise<void> {
+  private async completeMinigame(ctx: ButtonContext<CookieCountdownButtonState>): Promise<void> {
     if (!ctx.game) throw new Error("Game data missing.");
     ctx.game.size++;
     await ctx.game.save();
@@ -65,41 +67,41 @@ export class HolidayCookieCountdownMinigame implements Minigame {
       .setTitle(ctx.game.name)
       .setDescription("You completed the Holiday Cookie Countdown! Your tree has grown!");
 
-    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
 
-    transitionToDefaultTreeView(ctx);
+    transitionToDefaultTreeView(ctx as ButtonContext);
   }
 
   public static buttons = [
     new Button(
       "minigame.holidaycookiecountdown.cookie",
       new ButtonBuilder().setEmoji({ name: "🍪" }).setStyle(1),
-      async (ctx: ButtonContext): Promise<void> => {
+      async (ctx: ButtonContext<CookieCountdownButtonState>): Promise<void> => {
         const timeout = ctx.timeouts.get(ctx.interaction.message.id);
         if (timeout) clearTimeout(timeout);
         ctx.timeouts.delete(ctx.interaction.message.id);
 
+        const currentStage = ctx.state?.currentStage ?? 0;
         const minigame = new HolidayCookieCountdownMinigame();
-        minigame.currentStage = ctx.state?.currentStage ?? 0;
-        minigame.currentStage++;
-        await minigame.nextStage(ctx);
+        await minigame.nextStage(ctx, currentStage + 1);
       }
     ),
     new Button(
       "minigame.holidaycookiecountdown.emptyplate",
       new ButtonBuilder().setEmoji({ name: "❌" }).setStyle(4),
-      async (ctx: ButtonContext): Promise<void> => {
+      async (ctx: ButtonContext<CookieCountdownButtonState>): Promise<void> => {
         const timeout = ctx.timeouts.get(ctx.interaction.message.id);
         if (timeout) clearTimeout(timeout);
         ctx.timeouts.delete(ctx.interaction.message.id);
+
         if (!ctx.game) throw new Error("Game data missing.");
         const embed = new EmbedBuilder()
           .setTitle(ctx.game.name)
           .setDescription("You clicked the empty plate. Better luck next time!");
 
-        ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+        await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
 
-        transitionToDefaultTreeView(ctx);
+        transitionToDefaultTreeView(ctx as ButtonContext);
       }
     )
   ];

--- a/src/minigames/HolidayCookieCountdownMinigame.ts
+++ b/src/minigames/HolidayCookieCountdownMinigame.ts
@@ -1,0 +1,106 @@
+import { ButtonContext, EmbedBuilder, MessageBuilder, ActionRowBuilder, Button, ButtonBuilder } from "interactions.ts";
+import { shuffleArray } from "../util/helpers/arrayHelper";
+import { buildTreeDisplayMessage, transitionToDefaultTreeView } from "../commands/Tree";
+import { Minigame, MinigameConfig } from "../util/types/minigame/MinigameType";
+
+const HOLIDAY_COOKIE_COUNTDOWN_MINIGAME_MAX_DURATION = 10 * 1000;
+
+export class HolidayCookieCountdownMinigame implements Minigame {
+  config: MinigameConfig = {
+    premiumGuildOnly: false
+  };
+
+  private cookieImages = [
+    "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/holiday-cookie-countdown/holiday-cookie-countdown-1.png",
+    "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/holiday-cookie-countdown/holiday-cookie-countdown-2.png"
+  ];
+
+  private currentStage = 0;
+  private maxStages = 3;
+
+  async start(ctx: ButtonContext): Promise<void> {
+    this.currentStage = 0;
+    await this.nextStage(ctx);
+  }
+
+  private async nextStage(ctx: ButtonContext): Promise<void> {
+    if (this.currentStage >= this.maxStages) {
+      await this.completeMinigame(ctx);
+      return;
+    }
+
+    const embed = new EmbedBuilder()
+      .setTitle("Holiday Cookie Countdown!")
+      .setDescription(`Stage ${this.currentStage + 1}: Click the 🍪 button as cookies appear. Each stage adds more cookies!`)
+      .setImage(this.cookieImages[Math.floor(Math.random() * this.cookieImages.length)])
+      .setFooter({ text: "Hurry! You have limited time!" });
+
+    const buttons = [
+      await ctx.manager.components.createInstance("minigame.holidaycookiecountdown.cookie"),
+      await ctx.manager.components.createInstance("minigame.holidaycookiecountdown.emptyplate")
+    ];
+
+    shuffleArray(buttons);
+
+    const message = new MessageBuilder().addComponents(new ActionRowBuilder().addComponents(...buttons));
+
+    message.addEmbed(embed);
+
+    await ctx.reply(message);
+
+    const timeoutId = setTimeout(async () => {
+      ctx.timeouts.delete(ctx.interaction.message.id);
+      await ctx.edit(await buildTreeDisplayMessage(ctx));
+    }, HOLIDAY_COOKIE_COUNTDOWN_MINIGAME_MAX_DURATION);
+
+    ctx.timeouts.set(ctx.interaction.message.id, timeoutId);
+  }
+
+  private async completeMinigame(ctx: ButtonContext): Promise<void> {
+    if (!ctx.game) throw new Error("Game data missing.");
+    ctx.game.size++;
+    await ctx.game.save();
+
+    const embed = new EmbedBuilder()
+      .setTitle(ctx.game.name)
+      .setDescription("You completed the Holiday Cookie Countdown! Your tree has grown!");
+
+    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+
+    transitionToDefaultTreeView(ctx);
+  }
+
+  public static buttons = [
+    new Button(
+      "minigame.holidaycookiecountdown.cookie",
+      new ButtonBuilder().setEmoji({ name: "🍪" }).setStyle(1),
+      async (ctx: ButtonContext): Promise<void> => {
+        const timeout = ctx.timeouts.get(ctx.interaction.message.id);
+        if (timeout) clearTimeout(timeout);
+        ctx.timeouts.delete(ctx.interaction.message.id);
+
+        const minigame = new HolidayCookieCountdownMinigame();
+        minigame.currentStage = ctx.state?.currentStage ?? 0;
+        minigame.currentStage++;
+        await minigame.nextStage(ctx);
+      }
+    ),
+    new Button(
+      "minigame.holidaycookiecountdown.emptyplate",
+      new ButtonBuilder().setEmoji({ name: "❌" }).setStyle(4),
+      async (ctx: ButtonContext): Promise<void> => {
+        const timeout = ctx.timeouts.get(ctx.interaction.message.id);
+        if (timeout) clearTimeout(timeout);
+        ctx.timeouts.delete(ctx.interaction.message.id);
+        if (!ctx.game) throw new Error("Game data missing.");
+        const embed = new EmbedBuilder()
+          .setTitle(ctx.game.name)
+          .setDescription("You clicked the empty plate. Better luck next time!");
+
+        ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+
+        transitionToDefaultTreeView(ctx);
+      }
+    )
+  ];
+}

--- a/src/minigames/HotCocoaMinigame.ts
+++ b/src/minigames/HotCocoaMinigame.ts
@@ -77,7 +77,7 @@ export class HotCocoaMinigame implements Minigame {
         const embed = new EmbedBuilder()
           .setTitle(ctx.game.name)
           .setImage("https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/hot-cocoa/hot-cocoa-1.jpg")
-          .setDescription("This hot cocoa is delicious! Your tree has grown!");
+          .setDescription("This hot cocoa is delicious! Your tree has grown 1ft!");
 
         ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
 
@@ -91,12 +91,12 @@ export class HotCocoaMinigame implements Minigame {
     ),
     new Button(
       "minigame.hotcocoa.spilledcocoa-2",
-      new ButtonBuilder().setEmoji({ name: "🍫" }).setStyle(4),
+      new ButtonBuilder().setEmoji({ name: "🍲" }).setStyle(4),
       HotCocoaMinigame.handleSpilledCocoaButton
     ),
     new Button(
       "minigame.hotcocoa.spilledcocoa-3",
-      new ButtonBuilder().setEmoji({ name: "🍫" }).setStyle(4),
+      new ButtonBuilder().setEmoji({ name: "🥤" }).setStyle(4),
       HotCocoaMinigame.handleSpilledCocoaButton
     )
   ];

--- a/src/minigames/MinigameFactory.ts
+++ b/src/minigames/MinigameFactory.ts
@@ -5,13 +5,19 @@ import { HotCocoaMinigame } from "./HotCocoaMinigame";
 import { GiftUnwrappingMinigame } from "./GiftUnwrappingMinigame";
 import { SnowballFightMinigame } from "./SnowballFightMinigame";
 import { GrinchHeistMinigame } from "./GrinchHeistMinigame";
+import { HolidayCookieCountdownMinigame } from "./HolidayCookieCountdownMinigame";
+import { TinselTwisterMinigame } from "./TinselTwisterMinigame";
+import { CarolingChoirMinigame } from "./CarolingChoirMinigame";
 
 const minigames: Minigame[] = [
   new SantaPresentMinigame(),
   new HotCocoaMinigame(),
   new GiftUnwrappingMinigame(),
   new SnowballFightMinigame(),
-  new GrinchHeistMinigame()
+  new GrinchHeistMinigame(),
+  new HolidayCookieCountdownMinigame(),
+  new TinselTwisterMinigame(),
+  new CarolingChoirMinigame()
 ];
 
 export async function startRandomMinigame(ctx: ButtonContext): Promise<boolean> {

--- a/src/minigames/SantaPresentMinigame.ts
+++ b/src/minigames/SantaPresentMinigame.ts
@@ -56,7 +56,7 @@ export class SantaPresentMinigame implements Minigame {
 
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
-      .setDescription("Enjoy your present! There was some magic inside which made your tree grow!")
+      .setDescription("Enjoy your present! There was some magic inside which made your tree grow 1ft!")
       .setImage(
         "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/santa-present/santa-present-minigame.jpg"
       );
@@ -92,12 +92,12 @@ export class SantaPresentMinigame implements Minigame {
     ),
     new Button(
       "minigame.santapresent.witch-2",
-      new ButtonBuilder().setEmoji({ name: "🧙" }).setStyle(4),
+      new ButtonBuilder().setEmoji({ name: "🥶" }).setStyle(4),
       SantaPresentMinigame.handleWitchButton
     ),
     new Button(
       "minigame.santapresent.witch-3",
-      new ButtonBuilder().setEmoji({ name: "🧙" }).setStyle(4),
+      new ButtonBuilder().setEmoji({ name: "🥶" }).setStyle(4),
       SantaPresentMinigame.handleWitchButton
     )
   ];

--- a/src/minigames/SnowballFightMinigame.ts
+++ b/src/minigames/SnowballFightMinigame.ts
@@ -26,7 +26,9 @@ export class SnowballFightMinigame implements Minigame {
 
     const buttons = [
       await ctx.manager.components.createInstance("minigame.snowballfight.snowball"),
-      await ctx.manager.components.createInstance("minigame.snowballfight.miss")
+      await ctx.manager.components.createInstance("minigame.snowballfight.miss-1"),
+      await ctx.manager.components.createInstance("minigame.snowballfight.miss-2"),
+      await ctx.manager.components.createInstance("minigame.snowballfight.miss-3")
     ];
 
     shuffleArray(buttons);
@@ -45,51 +47,70 @@ export class SnowballFightMinigame implements Minigame {
     ctx.timeouts.set(ctx.interaction.message.id, timeoutId);
   }
 
+  private static async handleSnowballButton(ctx: ButtonContext): Promise<void> {
+    const timeout = ctx.timeouts.get(ctx.interaction.message.id);
+    if (timeout) clearTimeout(timeout);
+    ctx.timeouts.delete(ctx.interaction.message.id);
+
+    if (!ctx.game) throw new Error("Game data missing.");
+
+    const randomOutcome = Math.random();
+    let message;
+
+    if (randomOutcome < 0.5) {
+      ctx.game.size++;
+      message = "Bullseye! You hit the target with a snowball and your tree grew 1ft taller!";
+    } else {
+      message = "You threw a snowball but missed the target. Better luck next time!";
+    }
+
+    await ctx.game.save();
+
+    const embed = new EmbedBuilder().setTitle(ctx.game.name).setDescription(message);
+    await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+
+    transitionToDefaultTreeView(ctx);
+  }
+
+  private static async handleMissButton(ctx: ButtonContext, isTimeout = false): Promise<void> {
+    const timeout = ctx.timeouts.get(ctx.interaction.message.id);
+    if (timeout) clearTimeout(timeout);
+    ctx.timeouts.delete(ctx.interaction.message.id);
+
+    if (!ctx.game) throw new Error("Game data missing.");
+    const embed = new EmbedBuilder()
+      .setTitle(ctx.game.name)
+      .setDescription("You missed the target. Better luck next time!");
+
+    if (isTimeout) {
+      await ctx.edit(new MessageBuilder().addEmbed(embed).setComponents([]));
+    } else {
+      await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    }
+
+    transitionToDefaultTreeView(ctx);
+  }
+
   public static buttons = [
     new Button(
       "minigame.snowballfight.snowball",
       new ButtonBuilder().setEmoji({ name: "❄️" }).setStyle(1),
-      async (ctx: ButtonContext): Promise<void> => {
-        const timeout = ctx.timeouts.get(ctx.interaction.message.id);
-        if (timeout) clearTimeout(timeout);
-        ctx.timeouts.delete(ctx.interaction.message.id);
-
-        if (!ctx.game) throw new Error("Game data missing.");
-
-        const randomOutcome = Math.random();
-        let message;
-
-        if (randomOutcome < 0.5) {
-          ctx.game.size++;
-          message = "Bullseye! You hit the target with a snowball and your tree grew taller!";
-        } else {
-          message = "You threw a snowball but missed the target. Better luck next time!";
-        }
-
-        await ctx.game.save();
-
-        const embed = new EmbedBuilder().setTitle(ctx.game.name).setDescription(message);
-        ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
-
-        transitionToDefaultTreeView(ctx);
-      }
+      SnowballFightMinigame.handleSnowballButton
     ),
     new Button(
-      "minigame.snowballfight.miss",
+      "minigame.snowballfight.miss-1",
       new ButtonBuilder().setEmoji({ name: "❌" }).setStyle(4),
-      async (ctx: ButtonContext): Promise<void> => {
-        const timeout = ctx.timeouts.get(ctx.interaction.message.id);
-        if (timeout) clearTimeout(timeout);
-        ctx.timeouts.delete(ctx.interaction.message.id);
-        if (!ctx.game) throw new Error("Game data missing.");
-        const embed = new EmbedBuilder()
-          .setTitle(ctx.game.name)
-          .setDescription("You missed the target. Better luck next time!");
-
-        ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
-
-        transitionToDefaultTreeView(ctx);
-      }
+      SnowballFightMinigame.handleMissButton
+    ),
+    new Button(
+      "minigame.snowballfight.miss-2",
+      new ButtonBuilder().setEmoji({ name: "🎅" }).setStyle(4),
+      SnowballFightMinigame.handleMissButton
+    ),
+    new Button(
+      "minigame.snowballfight.miss-3",
+      new ButtonBuilder().setEmoji({ name: "⛄" }).setStyle(4),
+      SnowballFightMinigame.handleMissButton
     )
   ];
 }

--- a/src/minigames/TinselTwisterMinigame.ts
+++ b/src/minigames/TinselTwisterMinigame.ts
@@ -1,0 +1,107 @@
+import { ButtonContext, EmbedBuilder, MessageBuilder, ActionRowBuilder, Button, ButtonBuilder } from "interactions.ts";
+import { shuffleArray } from "../util/helpers/arrayHelper";
+import { buildTreeDisplayMessage, transitionToDefaultTreeView } from "../commands/Tree";
+import { Minigame, MinigameConfig } from "../util/types/minigame/MinigameType";
+
+const TINSEL_TWISTER_MINIGAME_MAX_DURATION = 10 * 1000;
+
+export class TinselTwisterMinigame implements Minigame {
+  config: MinigameConfig = {
+    premiumGuildOnly: true
+  };
+
+  private tinselImages = [
+    "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/tinsel-twister/tinsel-twister-1.jpg",
+    "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/tinsel-twister/tinsel-twister-2.jpg",
+    "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/tinsel-twister/tinsel-twister-3.jpg"
+  ];
+
+  private currentStage = 0;
+  private maxStages = 3;
+
+  async start(ctx: ButtonContext): Promise<void> {
+    this.currentStage = 0;
+    await this.nextStage(ctx);
+  }
+
+  private async nextStage(ctx: ButtonContext): Promise<void> {
+    if (this.currentStage >= this.maxStages) {
+      await this.completeMinigame(ctx);
+      return;
+    }
+
+    const embed = new EmbedBuilder()
+      .setTitle("Tinsel Twister!")
+      .setDescription(`Stage ${this.currentStage + 1}: Click the 🎀 to add tinsel to the tree. Each round requires a faster rhythm!`)
+      .setImage(this.tinselImages[Math.floor(Math.random() * this.tinselImages.length)])
+      .setFooter({ text: "Hurry! Wrap the tree in sparkling tinsel!" });
+
+    const buttons = [
+      await ctx.manager.components.createInstance("minigame.tinseltwister.tinsel"),
+      await ctx.manager.components.createInstance("minigame.tinseltwister.empty")
+    ];
+
+    shuffleArray(buttons);
+
+    const message = new MessageBuilder().addComponents(new ActionRowBuilder().addComponents(...buttons));
+
+    message.addEmbed(embed);
+
+    await ctx.reply(message);
+
+    const timeoutId = setTimeout(async () => {
+      ctx.timeouts.delete(ctx.interaction.message.id);
+      await ctx.edit(await buildTreeDisplayMessage(ctx));
+    }, TINSEL_TWISTER_MINIGAME_MAX_DURATION);
+
+    ctx.timeouts.set(ctx.interaction.message.id, timeoutId);
+  }
+
+  private async completeMinigame(ctx: ButtonContext): Promise<void> {
+    if (!ctx.game) throw new Error("Game data missing.");
+    ctx.game.size++;
+    await ctx.game.save();
+
+    const embed = new EmbedBuilder()
+      .setTitle(ctx.game.name)
+      .setDescription("You completed the Tinsel Twister! Your tree has grown!");
+
+    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+
+    transitionToDefaultTreeView(ctx);
+  }
+
+  public static buttons = [
+    new Button(
+      "minigame.tinseltwister.tinsel",
+      new ButtonBuilder().setEmoji({ name: "🎀" }).setStyle(1),
+      async (ctx: ButtonContext): Promise<void> => {
+        const timeout = ctx.timeouts.get(ctx.interaction.message.id);
+        if (timeout) clearTimeout(timeout);
+        ctx.timeouts.delete(ctx.interaction.message.id);
+
+        const minigame = new TinselTwisterMinigame();
+        minigame.currentStage = ctx.state?.currentStage ?? 0;
+        minigame.currentStage++;
+        await minigame.nextStage(ctx);
+      }
+    ),
+    new Button(
+      "minigame.tinseltwister.empty",
+      new ButtonBuilder().setEmoji({ name: "❌" }).setStyle(4),
+      async (ctx: ButtonContext): Promise<void> => {
+        const timeout = ctx.timeouts.get(ctx.interaction.message.id);
+        if (timeout) clearTimeout(timeout);
+        ctx.timeouts.delete(ctx.interaction.message.id);
+        if (!ctx.game) throw new Error("Game data missing.");
+        const embed = new EmbedBuilder()
+          .setTitle(ctx.game.name)
+          .setDescription("You missed the tinsel. Better luck next time!");
+
+        ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+
+        transitionToDefaultTreeView(ctx);
+      }
+    )
+  ];
+}

--- a/src/minigames/TinselTwisterMinigame.ts
+++ b/src/minigames/TinselTwisterMinigame.ts
@@ -5,6 +5,10 @@ import { Minigame, MinigameConfig } from "../util/types/minigame/MinigameType";
 
 const TINSEL_TWISTER_MINIGAME_MAX_DURATION = 10 * 1000;
 
+type TinselTwisterButtonState = {
+  currentStage: number;
+};
+
 export class TinselTwisterMinigame implements Minigame {
   config: MinigameConfig = {
     premiumGuildOnly: true
@@ -16,48 +20,48 @@ export class TinselTwisterMinigame implements Minigame {
     "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/tinsel-twister/tinsel-twister-3.jpg"
   ];
 
-  private currentStage = 0;
   private maxStages = 3;
 
   async start(ctx: ButtonContext): Promise<void> {
-    this.currentStage = 0;
-    await this.nextStage(ctx);
+    await this.nextStage(ctx, 0);
   }
 
-  private async nextStage(ctx: ButtonContext): Promise<void> {
-    if (this.currentStage >= this.maxStages) {
+  private async nextStage(ctx: ButtonContext<TinselTwisterButtonState>, currentStage: number): Promise<void> {
+    if (currentStage >= this.maxStages) {
       await this.completeMinigame(ctx);
       return;
     }
 
     const embed = new EmbedBuilder()
       .setTitle("Tinsel Twister!")
-      .setDescription(`Stage ${this.currentStage + 1}: Click the 🎀 to add tinsel to the tree. Each round requires a faster rhythm!`)
+      .setDescription(
+        `Stage ${currentStage + 1}: Click the 🎀 to add tinsel to the tree. Each round requires a faster rhythm!`
+      )
       .setImage(this.tinselImages[Math.floor(Math.random() * this.tinselImages.length)])
       .setFooter({ text: "Hurry! Wrap the tree in sparkling tinsel!" });
 
     const buttons = [
-      await ctx.manager.components.createInstance("minigame.tinseltwister.tinsel"),
-      await ctx.manager.components.createInstance("minigame.tinseltwister.empty")
+      await ctx.manager.components.createInstance("minigame.tinseltwister.tinsel", { currentStage }),
+      await ctx.manager.components.createInstance("minigame.tinseltwister.empty", { currentStage })
     ];
 
     shuffleArray(buttons);
 
-    const message = new MessageBuilder().addComponents(new ActionRowBuilder().addComponents(...buttons));
-
-    message.addEmbed(embed);
+    const message = new MessageBuilder()
+      .addEmbed(embed)
+      .addComponents(new ActionRowBuilder().addComponents(...buttons));
 
     await ctx.reply(message);
 
     const timeoutId = setTimeout(async () => {
       ctx.timeouts.delete(ctx.interaction.message.id);
-      await ctx.edit(await buildTreeDisplayMessage(ctx));
+      await ctx.edit(await buildTreeDisplayMessage(ctx as ButtonContext));
     }, TINSEL_TWISTER_MINIGAME_MAX_DURATION);
 
     ctx.timeouts.set(ctx.interaction.message.id, timeoutId);
   }
 
-  private async completeMinigame(ctx: ButtonContext): Promise<void> {
+  private async completeMinigame(ctx: ButtonContext<TinselTwisterButtonState>): Promise<void> {
     if (!ctx.game) throw new Error("Game data missing.");
     ctx.game.size++;
     await ctx.game.save();
@@ -66,41 +70,41 @@ export class TinselTwisterMinigame implements Minigame {
       .setTitle(ctx.game.name)
       .setDescription("You completed the Tinsel Twister! Your tree has grown!");
 
-    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
 
-    transitionToDefaultTreeView(ctx);
+    transitionToDefaultTreeView(ctx as ButtonContext);
   }
 
   public static buttons = [
     new Button(
       "minigame.tinseltwister.tinsel",
       new ButtonBuilder().setEmoji({ name: "🎀" }).setStyle(1),
-      async (ctx: ButtonContext): Promise<void> => {
+      async (ctx: ButtonContext<TinselTwisterButtonState>): Promise<void> => {
         const timeout = ctx.timeouts.get(ctx.interaction.message.id);
         if (timeout) clearTimeout(timeout);
         ctx.timeouts.delete(ctx.interaction.message.id);
 
+        const currentStage = ctx.state?.currentStage ?? 0;
         const minigame = new TinselTwisterMinigame();
-        minigame.currentStage = ctx.state?.currentStage ?? 0;
-        minigame.currentStage++;
-        await minigame.nextStage(ctx);
+        await minigame.nextStage(ctx, currentStage + 1);
       }
     ),
     new Button(
       "minigame.tinseltwister.empty",
       new ButtonBuilder().setEmoji({ name: "❌" }).setStyle(4),
-      async (ctx: ButtonContext): Promise<void> => {
+      async (ctx: ButtonContext<TinselTwisterButtonState>): Promise<void> => {
         const timeout = ctx.timeouts.get(ctx.interaction.message.id);
         if (timeout) clearTimeout(timeout);
         ctx.timeouts.delete(ctx.interaction.message.id);
+
         if (!ctx.game) throw new Error("Game data missing.");
         const embed = new EmbedBuilder()
           .setTitle(ctx.game.name)
           .setDescription("You missed the tinsel. Better luck next time!");
 
-        ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+        await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
 
-        transitionToDefaultTreeView(ctx);
+        transitionToDefaultTreeView(ctx as ButtonContext);
       }
     )
   ];


### PR DESCRIPTION
Fixes #67

Add new minigames: Holiday Cookie Countdown, Tinsel Twister, and Caroling Choir.

* **Holiday Cookie Countdown Minigame**
  - Create `HolidayCookieCountdownMinigame` class in `src/minigames/HolidayCookieCountdownMinigame.ts`.
  - Implement multiple stages with randomized buttons using `shuffleArray`.
  - Add timeout functionality and progress tracking.
  - Add buttons for cookie and empty plate interactions.

* **Tinsel Twister Minigame**
  - Create `TinselTwisterMinigame` class in `src/minigames/TinselTwisterMinigame.ts`.
  - Implement multiple stages with randomized buttons using `shuffleArray`.
  - Add timeout functionality and progress tracking.
  - Add buttons for tinsel and empty interactions.

* **Caroling Choir Minigame**
  - Create `CarolingChoirMinigame` class in `src/minigames/CarolingChoirMinigame.ts`.
  - Implement multiple stages with randomized buttons using `shuffleArray`.
  - Add timeout functionality and progress tracking.
  - Add buttons for note and wrong note interactions.

* **Minigame Factory**
  - Import new minigame classes in `src/minigames/MinigameFactory.ts`.
  - Add instances of new minigames to the `minigames` array.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GewoonJaap/grow-a-christmas-tree/issues/67?shareId=4e1cb2ce-e4cc-4b66-a79c-b63483562813).