### PR TITLE
Add notifications when the tree is ready to water

### DIFF
--- a/src/commands/NotificationSettings.ts
+++ b/src/commands/NotificationSettings.ts
@@ -5,8 +5,7 @@ import {
   SlashCommandBuilder,
   SlashCommandChannelOption,
   SlashCommandContext,
-  SlashCommandRoleOption,
-  SlashCommandStringOption
+  SlashCommandRoleOption
 } from "interactions.ts";
 import { Guild } from "../models/Guild";
 import { createWebhook } from "../util/discord/DiscordWebhookHelper";

--- a/src/commands/NotificationSettings.ts
+++ b/src/commands/NotificationSettings.ts
@@ -1,4 +1,5 @@
 import {
+  EmbedBuilder,
   ISlashCommand,
   MessageBuilder,
   SlashCommandBooleanOption,
@@ -29,6 +30,16 @@ export class NotificationSettings implements ISlashCommand {
       return ctx.reply(
         new MessageBuilder().setContent("Use /plant to plant a tree for your server first.").setEphemeral(true)
       );
+
+    if (!ctx.game.hasAiAccess) {
+      const embed = new EmbedBuilder()
+        .setDescription(
+          "You have just discovered a premium only feature! Visit the [shop](https://discord.com/application-directory/1050722873569968128/store) or click the bot avatar and buy the Festive Forest subscription to gain access."
+        )
+        .setTitle("Woah there!")
+        .setFooter({ text: "Enjoying the bot? Consider supporting us by buying a subscription!" });
+      return ctx.reply(new MessageBuilder().addEmbed(embed).setEphemeral(true));
+    }
     const role = ctx.options.get("role")?.value as string | undefined;
     const channel = ctx.options.get("channel")?.value as string | undefined;
     const enabled = ctx.options.get("enabled")?.value as boolean | undefined;
@@ -42,9 +53,10 @@ export class NotificationSettings implements ISlashCommand {
     }
 
     if (!role || !channel) {
-      return ctx.reply(
-        new MessageBuilder().setContent("Please provide the following options: role or channel.").setEphemeral(true)
-      );
+      const embed = new EmbedBuilder()
+        .setTitle("Missing Options")
+        .setDescription("Please provide the following options: role or channel.");
+      return ctx.reply(new MessageBuilder().addEmbed(embed).setEphemeral(true));
     }
 
     const updateData: { notificationRoleId?: string; webhookId?: string; webhookToken?: string } = {};

--- a/src/commands/NotificationSettings.ts
+++ b/src/commands/NotificationSettings.ts
@@ -1,0 +1,57 @@
+import {
+  ISlashCommand,
+  MessageBuilder,
+  SlashCommandBuilder,
+  SlashCommandContext,
+  SlashCommandStringOption
+} from "interactions.ts";
+import { Guild } from "../models/Guild";
+
+const builder = new SlashCommandBuilder("notificationSettings", "Configure the role and channel for notifications.")
+  .addStringOption(new SlashCommandStringOption("role", "Role to ping for notifications").setRequired(false))
+  .addStringOption(new SlashCommandStringOption("channel", "Channel to send notifications").setRequired(false));
+
+builder.setDMEnabled(false);
+
+export class NotificationSettings implements ISlashCommand {
+  public builder = builder;
+
+  public handler = async (ctx: SlashCommandContext): Promise<void> => {
+    const role = ctx.options.get("role")?.value as string | undefined;
+    const channel = ctx.options.get("channel")?.value as string | undefined;
+
+    if (!role && !channel) {
+      return ctx.reply(
+        new MessageBuilder().setContent(
+          "Please provide at least one option: role or channel."
+        ).setEphemeral(true)
+      );
+    }
+
+    if (role === "off" || channel === "off") {
+      await Guild.updateOne(
+        { id: ctx.interaction.guild_id },
+        { $unset: { notificationRoleId: "", notificationChannelId: "" } }
+      );
+      return ctx.reply(
+        new MessageBuilder().setContent(
+          "Notifications have been turned off."
+        ).setEphemeral(true)
+      );
+    }
+
+    const updateData: { notificationRoleId?: string; notificationChannelId?: string } = {};
+    if (role) updateData.notificationRoleId = role;
+    if (channel) updateData.notificationChannelId = channel;
+
+    await Guild.updateOne({ id: ctx.interaction.guild_id }, { $set: updateData });
+
+    return ctx.reply(
+      new MessageBuilder().setContent(
+        `Notification settings updated. Role: ${role ?? "unchanged"}, Channel: ${channel ?? "unchanged"}`
+      ).setEphemeral(true)
+    );
+  };
+
+  public components = [];
+}

--- a/src/commands/NotificationSettings.ts
+++ b/src/commands/NotificationSettings.ts
@@ -1,15 +1,20 @@
 import {
   ISlashCommand,
   MessageBuilder,
+  SlashCommandBooleanOption,
   SlashCommandBuilder,
+  SlashCommandChannelOption,
   SlashCommandContext,
+  SlashCommandRoleOption,
   SlashCommandStringOption
 } from "interactions.ts";
 import { Guild } from "../models/Guild";
+import { createWebhook } from "../util/discord/DiscordWebhookHelper";
 
 const builder = new SlashCommandBuilder("notificationSettings", "Configure the role and channel for notifications.")
-  .addStringOption(new SlashCommandStringOption("role", "Role to ping for notifications").setRequired(false))
-  .addStringOption(new SlashCommandStringOption("channel", "Channel to send notifications").setRequired(false));
+  .addRoleOption(new SlashCommandRoleOption("role", "Role to ping for notifications").setRequired(false))
+  .addChannelOption(new SlashCommandChannelOption("channel", "Channel to send notifications").setRequired(false))
+  .addBooleanOption(new SlashCommandBooleanOption("enabled", "Turn notification on or off").setRequired(true));
 
 builder.setDMEnabled(false);
 
@@ -17,39 +22,50 @@ export class NotificationSettings implements ISlashCommand {
   public builder = builder;
 
   public handler = async (ctx: SlashCommandContext): Promise<void> => {
+    if (ctx.isDM)
+      return ctx.reply(
+        new MessageBuilder().setContent("This command can only be used in a server.").setEphemeral(true)
+      );
+    if (!ctx.game)
+      return ctx.reply(
+        new MessageBuilder().setContent("Use /plant to plant a tree for your server first.").setEphemeral(true)
+      );
     const role = ctx.options.get("role")?.value as string | undefined;
     const channel = ctx.options.get("channel")?.value as string | undefined;
+    const enabled = ctx.options.get("enabled")?.value as boolean | undefined;
 
-    if (!role && !channel) {
-      return ctx.reply(
-        new MessageBuilder().setContent(
-          "Please provide at least one option: role or channel."
-        ).setEphemeral(true)
-      );
-    }
-
-    if (role === "off" || channel === "off") {
+    if (!enabled) {
       await Guild.updateOne(
         { id: ctx.interaction.guild_id },
-        { $unset: { notificationRoleId: "", notificationChannelId: "" } }
+        { $unset: { notificationRoleId: "", webhookId: "", webhookToken: "" } }
       );
+      return ctx.reply(new MessageBuilder().setContent("Notifications have been turned off.").setEphemeral(true));
+    }
+
+    if (!role || !channel) {
       return ctx.reply(
-        new MessageBuilder().setContent(
-          "Notifications have been turned off."
-        ).setEphemeral(true)
+        new MessageBuilder().setContent("Please provide the following options: role or channel.").setEphemeral(true)
       );
     }
 
-    const updateData: { notificationRoleId?: string; notificationChannelId?: string } = {};
-    if (role) updateData.notificationRoleId = role;
-    if (channel) updateData.notificationChannelId = channel;
+    const updateData: { notificationRoleId?: string; webhookId?: string; webhookToken?: string } = {};
+
+    const webhook = await createWebhook(
+      ctx.interaction.channel_id,
+      "Tree Notifications",
+      "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/stage-5.png"
+    );
+
+    updateData.notificationRoleId = role;
+    updateData.webhookId = webhook.id;
+    updateData.webhookToken = webhook.token;
 
     await Guild.updateOne({ id: ctx.interaction.guild_id }, { $set: updateData });
 
     return ctx.reply(
-      new MessageBuilder().setContent(
-        `Notification settings updated. Role: ${role ?? "unchanged"}, Channel: ${channel ?? "unchanged"}`
-      ).setEphemeral(true)
+      new MessageBuilder()
+        .setContent(`Notification settings updated. Role: ${role}, Channel: ${channel}, Enabled: ${enabled}`)
+        .setEphemeral(true)
     );
   };
 

--- a/src/commands/NotificationSettings.ts
+++ b/src/commands/NotificationSettings.ts
@@ -37,7 +37,7 @@ export class NotificationSettings implements ISlashCommand {
     if (!ctx.game.hasAiAccess) {
       const embed = new EmbedBuilder()
         .setDescription(
-          "You have just discovered a premium only feature! Visit the [shop](https://discord.com/application-directory/1050722873569968128/store) or click the bot avatar and buy the Festive Forest subscription to gain access."
+          "You have just discovered a premium only feature! Visit the [shop](https://discord.com/application-directory/1050722873569968128/store) or click the bot avatar and buy the [Festive Forest subscription](https://discord.com/application-directory/1050722873569968128/store/1298016263687110697) to gain access."
         )
         .setTitle("Woah there!")
         .setFooter({ text: "Enjoying the bot? Consider supporting us by buying a subscription!" });

--- a/src/commands/NotificationSettings.ts
+++ b/src/commands/NotificationSettings.ts
@@ -50,23 +50,34 @@ export class NotificationSettings implements ISlashCommand {
 
     const updateData: { notificationRoleId?: string; webhookId?: string; webhookToken?: string } = {};
 
-    const webhook = await createWebhook(
-      ctx.interaction.channel_id,
-      "Tree Notifications",
-      "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/stage-5.png"
-    );
+    try {
+      const webhook = await createWebhook(
+        ctx.interaction.channel_id,
+        "Tree Notifications",
+        "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/stage-5.png"
+      );
 
-    updateData.notificationRoleId = role;
-    updateData.webhookId = webhook.id;
-    updateData.webhookToken = webhook.token;
+      updateData.notificationRoleId = role;
+      updateData.webhookId = webhook.id;
+      updateData.webhookToken = webhook.token;
 
-    await Guild.updateOne({ id: ctx.interaction.guild_id }, { $set: updateData });
+      await Guild.updateOne({ id: ctx.interaction.guild_id }, { $set: updateData });
 
-    return ctx.reply(
-      new MessageBuilder()
-        .setContent(`Notification settings updated. Role: ${role}, Channel: ${channel}, Enabled: ${enabled}`)
-        .setEphemeral(true)
-    );
+      return ctx.reply(
+        new MessageBuilder()
+          .setContent(`Notification settings updated. Role: ${role}, Channel: ${channel}, Enabled: ${enabled}`)
+          .setEphemeral(true)
+      );
+    } catch (err) {
+      console.error(err);
+      return ctx.reply(
+        new MessageBuilder()
+          .setContent(
+            "An error occurred while updating the notification settings. Does the bot have the Manage Webhooks permission?"
+          )
+          .setEphemeral(true)
+      );
+    }
   };
 
   public components = [];

--- a/src/commands/Tree.ts
+++ b/src/commands/Tree.ts
@@ -217,7 +217,13 @@ export async function buildTreeDisplayMessage(ctx: SlashCommandContext | ButtonC
         ctx.interaction.message.id,
         setTimeout(async () => {
           ctx.timeouts.delete(ctx.interaction?.message?.id ?? "broken");
-          if (ctx.game && ctx.game.notificationRoleId && ctx.game.webhookId && ctx.game.webhookToken) {
+          if (
+            ctx.game &&
+            ctx.game.hasAiAccess &&
+            ctx.game.notificationRoleId &&
+            ctx.game.webhookId &&
+            ctx.game.webhookToken
+          ) {
             await sendAndDeleteWebhookMessage(
               ctx.game.webhookId,
               ctx.game.webhookToken,

--- a/src/commands/Tree.ts
+++ b/src/commands/Tree.ts
@@ -20,6 +20,7 @@ import { HotCocoaMinigame } from "../minigames/HotCocoaMinigame";
 import { GiftUnwrappingMinigame } from "../minigames/GiftUnwrappingMinigame";
 import { SnowballFightMinigame } from "../minigames/SnowballFightMinigame";
 import { GrinchHeistMinigame } from "../minigames/GrinchHeistMinigame";
+import { Guild } from "../models/Guild";
 
 const MINIGAME_CHANCE = 0.4;
 const MINIGAME_DELAY_SECONDS = 5 * 60;
@@ -105,6 +106,20 @@ export class Tree implements ISlashCommand {
           await ctx.game.save();
           const minigameStarted = await startRandomMinigame(ctx);
           if (minigameStarted) return;
+        }
+
+        // Send notification when the tree is ready to water
+        const guild = await Guild.findOne({ id: ctx.interaction.guild_id });
+        if (guild && guild.notificationRoleId && guild.notificationChannelId) {
+          const notificationMessage = new MessageBuilder().addEmbed(
+            new EmbedBuilder().setDescription(`<@&${guild.notificationRoleId}> The tree is ready to be watered! 🌲💧`)
+          );
+
+          const notificationChannel = await ctx.client.channels.fetch(guild.notificationChannelId);
+          if (notificationChannel && notificationChannel.isText()) {
+            const sentMessage = await notificationChannel.send(notificationMessage);
+            setTimeout(() => sentMessage.delete(), 60000); // Delete the notification message after 60 seconds
+          }
         }
 
         return ctx.reply(await buildTreeDisplayMessage(ctx));

--- a/src/commands/Tree.ts
+++ b/src/commands/Tree.ts
@@ -20,12 +20,10 @@ import { HotCocoaMinigame } from "../minigames/HotCocoaMinigame";
 import { GiftUnwrappingMinigame } from "../minigames/GiftUnwrappingMinigame";
 import { SnowballFightMinigame } from "../minigames/SnowballFightMinigame";
 import { GrinchHeistMinigame } from "../minigames/GrinchHeistMinigame";
-import { Guild } from "../models/Guild";
 import { sendAndDeleteWebhookMessage } from "../util/TreeWateringNotification";
 import { HolidayCookieCountdownMinigame } from "../minigames/HolidayCookieCountdownMinigame";
 import { TinselTwisterMinigame } from "../minigames/TinselTwisterMinigame";
 import { CarolingChoirMinigame } from "../minigames/CarolingChoirMinigame";
-
 
 const MINIGAME_CHANCE = 0.4;
 const MINIGAME_DELAY_SECONDS = 5 * 60;

--- a/src/commands/Tree.ts
+++ b/src/commands/Tree.ts
@@ -217,20 +217,7 @@ export async function buildTreeDisplayMessage(ctx: SlashCommandContext | ButtonC
         ctx.interaction.message.id,
         setTimeout(async () => {
           ctx.timeouts.delete(ctx.interaction?.message?.id ?? "broken");
-          if (
-            ctx.game &&
-            ctx.game.hasAiAccess &&
-            ctx.game.notificationRoleId &&
-            ctx.game.webhookId &&
-            ctx.game.webhookToken
-          ) {
-            await sendAndDeleteWebhookMessage(
-              ctx.game.webhookId,
-              ctx.game.webhookToken,
-              ctx.game.notificationRoleId,
-              "The tree is ready to be watered! 🌲💧"
-            );
-          }
+          sendWebhookOnWateringReady(ctx);
           await ctx.edit(await buildTreeDisplayMessage(ctx));
         }, canBeWateredAt * 1000 - Date.now())
       );
@@ -240,4 +227,21 @@ export async function buildTreeDisplayMessage(ctx: SlashCommandContext | ButtonC
   message.addEmbed(embed);
 
   return message;
+}
+
+async function sendWebhookOnWateringReady(ctx: SlashCommandContext | ButtonContext) {
+  if (
+    ctx.game &&
+    (ctx.game.hasAiAccess || process.env.DEV_MODE) &&
+    ctx.game.notificationRoleId &&
+    ctx.game.webhookId &&
+    ctx.game.webhookToken
+  ) {
+    await sendAndDeleteWebhookMessage(
+      ctx.game.webhookId,
+      ctx.game.webhookToken,
+      ctx.game.notificationRoleId,
+      "The tree is ready to be watered! 🌲💧"
+    );
+  }
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -6,3 +6,4 @@ export * from "./Plant";
 export * from "./Profile";
 export * from "./Tree";
 export * from "./Recycle";
+export * from "./NotificationSettings";

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import {
 } from "interactions.ts";
 import { connect, HydratedDocument } from "mongoose";
 import { createClient } from "redis";
-import { About, Forest, Leaderboard, Ping, Plant, Profile, Tree, Recycle } from "./commands";
+import { About, Forest, Leaderboard, Ping, Plant, Profile, Tree, Recycle, NotificationSettings } from "./commands";
 import { Guild, IGuild } from "./models/Guild";
 import { fetchStats } from "./api/stats";
 import { Feedback } from "./commands/Feedback";
@@ -93,7 +93,8 @@ if (keys.some((key) => !(key in process.env))) {
       new Profile(),
       new About(),
       new Recycle(),
-      new Feedback()
+      new Feedback(),
+      new NotificationSettings()
     ],
     false
   );

--- a/src/models/Guild.ts
+++ b/src/models/Guild.ts
@@ -18,6 +18,9 @@ interface IGuild {
   plantedAt: number;
 
   contributors: IContributor[];
+
+  notificationRoleId?: string;
+  notificationChannelId?: string;
 }
 
 interface IContributor {
@@ -49,7 +52,10 @@ const GuildSchema = new Schema<IGuild>({
   lastWateredBy: { type: String, required: false },
   lastWateredAt: { type: Number, required: false },
 
-  contributors: { type: [ContributorSchema], required: true, default: [] }
+  contributors: { type: [ContributorSchema], required: true, default: [] },
+
+  notificationRoleId: { type: String, required: false },
+  notificationChannelId: { type: String, required: false }
 });
 
 const Contributor = model<IContributor>("Contributor", ContributorSchema);

--- a/src/models/Guild.ts
+++ b/src/models/Guild.ts
@@ -20,7 +20,8 @@ interface IGuild {
   contributors: IContributor[];
 
   notificationRoleId?: string;
-  notificationChannelId?: string;
+  webhookId?: string;
+  webhookToken?: string;
 }
 
 interface IContributor {
@@ -55,7 +56,8 @@ const GuildSchema = new Schema<IGuild>({
   contributors: { type: [ContributorSchema], required: true, default: [] },
 
   notificationRoleId: { type: String, required: false },
-  notificationChannelId: { type: String, required: false }
+  webhookId: { type: String, required: false },
+  webhookToken: { type: String, required: false }
 });
 
 const Contributor = model<IContributor>("Contributor", ContributorSchema);

--- a/src/util/TreeWateringNotification.ts
+++ b/src/util/TreeWateringNotification.ts
@@ -1,0 +1,24 @@
+import { sendWebhookMessage, deleteWebhookMessage } from "../util/discord/DiscordWebhookHelper";
+
+export async function sendAndDeleteWebhookMessage(
+  webhookId: string,
+  webhookToken: string,
+  roleId: string,
+  content: string
+): Promise<void> {
+  try {
+    // Send the webhook message
+    const messageContent = `<@&${roleId}> ${content}`;
+    await sendWebhookMessage(webhookId, webhookToken, messageContent);
+
+    // Here you would normally get the message ID from the response of sendWebhookMessage
+    // For now, we'll assume you will supply the message ID later
+    const messageId = "MESSAGE_ID_TO_BE_SUPPLIED";
+
+    setTimeout(async () => {
+      await deleteWebhookMessage(webhookId, webhookToken, messageId);
+    }, 10 * 1000); // 10 seconds
+  } catch (error) {
+    console.error(error);
+  }
+}

--- a/src/util/TreeWateringNotification.ts
+++ b/src/util/TreeWateringNotification.ts
@@ -9,14 +9,10 @@ export async function sendAndDeleteWebhookMessage(
   try {
     // Send the webhook message
     const messageContent = `<@&${roleId}> ${content}`;
-    await sendWebhookMessage(webhookId, webhookToken, messageContent);
-
-    // Here you would normally get the message ID from the response of sendWebhookMessage
-    // For now, we'll assume you will supply the message ID later
-    const messageId = "MESSAGE_ID_TO_BE_SUPPLIED";
+    const result = await sendWebhookMessage(webhookId, webhookToken, messageContent);
 
     setTimeout(async () => {
-      await deleteWebhookMessage(webhookId, webhookToken, messageId);
+      await deleteWebhookMessage(webhookId, webhookToken, result.id);
     }, 10 * 1000); // 10 seconds
   } catch (error) {
     console.error(error);

--- a/src/util/discord/DiscordWebhookHelper.ts
+++ b/src/util/discord/DiscordWebhookHelper.ts
@@ -1,6 +1,10 @@
 import { WebhookCreatedResponse, WebhookMessageResponse } from "../types/discord/DiscordTypeExtension";
 
-export async function createWebhook(channelId: string, name: string, avatarUrl: string): Promise<WebhookCreatedResponse> {
+export async function createWebhook(
+  channelId: string,
+  name: string,
+  avatarUrl: string
+): Promise<WebhookCreatedResponse> {
   const response = await fetch(`https://discord.com/api/v10/channels/${channelId}/webhooks`, {
     method: "POST",
     headers: {

--- a/src/util/discord/DiscordWebhookHelper.ts
+++ b/src/util/discord/DiscordWebhookHelper.ts
@@ -1,6 +1,6 @@
-import { Webhook, WebhookMessageResponse } from "../types/discord/DiscordTypeExtension";
+import { WebhookCreatedResponse, WebhookMessageResponse } from "../types/discord/DiscordTypeExtension";
 
-export async function createWebhook(channelId: string, name: string, avatarUrl: string): Promise<Webhook> {
+export async function createWebhook(channelId: string, name: string, avatarUrl: string): Promise<WebhookCreatedResponse> {
   const response = await fetch(`https://discord.com/api/v10/channels/${channelId}/webhooks`, {
     method: "POST",
     headers: {

--- a/src/util/discord/DiscordWebhookHelper.ts
+++ b/src/util/discord/DiscordWebhookHelper.ts
@@ -1,4 +1,4 @@
-import { Webhook } from "../types/discord/DiscordTypeExtension";
+import { Webhook, WebhookMessageResponse } from "../types/discord/DiscordTypeExtension";
 
 export async function createWebhook(channelId: string, name: string, avatarUrl: string): Promise<Webhook> {
   const response = await fetch(`https://discord.com/api/v10/channels/${channelId}/webhooks`, {
@@ -20,7 +20,11 @@ export async function createWebhook(channelId: string, name: string, avatarUrl: 
   return await response.json();
 }
 
-export async function sendWebhookMessage(webhookId: string, webhookToken: string, content: string): Promise<void> {
+export async function sendWebhookMessage(
+  webhookId: string,
+  webhookToken: string,
+  content: string
+): Promise<WebhookMessageResponse> {
   const response = await fetch(`https://discord.com/api/v10/webhooks/${webhookId}/${webhookToken}?wait=true`, {
     method: "POST",
     headers: {
@@ -34,6 +38,8 @@ export async function sendWebhookMessage(webhookId: string, webhookToken: string
   if (!response.ok) {
     throw new Error(`Error sending webhook message: ${response.statusText}`);
   }
+
+  return await response.json();
 }
 
 export async function deleteWebhookMessage(webhookId: string, webhookToken: string, messageId: string): Promise<void> {

--- a/src/util/discord/DiscordWebhookHelper.ts
+++ b/src/util/discord/DiscordWebhookHelper.ts
@@ -29,13 +29,14 @@ export async function sendWebhookMessage(
   webhookToken: string,
   content: string
 ): Promise<WebhookMessageResponse> {
-  const response = await fetch(`https://discord.com/api/v10/webhooks/${webhookId}/${webhookToken}?wait=true`, {
+  const response = await fetch(`https://discord.com/api/webhooks/${webhookId}/${webhookToken}?wait=true`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json"
     },
     body: JSON.stringify({
-      content: content
+      content: content,
+      avatar_url: "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/stage-5.png"
     })
   });
 

--- a/src/util/discord/DiscordWebhookHelper.ts
+++ b/src/util/discord/DiscordWebhookHelper.ts
@@ -1,0 +1,50 @@
+import { Webhook } from "../types/discord/DiscordTypeExtension";
+
+export async function createWebhook(channelId: string, name: string, avatarUrl: string): Promise<Webhook> {
+  const response = await fetch(`https://discord.com/api/v10/channels/${channelId}/webhooks`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bot ${process.env.TOKEN}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      name: name,
+      avatar: avatarUrl
+    })
+  });
+
+  if (!response.ok) {
+    throw new Error(`Error creating webhook: ${response.statusText}`);
+  }
+
+  return await response.json();
+}
+
+export async function sendWebhookMessage(webhookId: string, webhookToken: string, content: string): Promise<void> {
+  const response = await fetch(`https://discord.com/api/v10/webhooks/${webhookId}/${webhookToken}?wait=true`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      content: content
+    })
+  });
+
+  if (!response.ok) {
+    throw new Error(`Error sending webhook message: ${response.statusText}`);
+  }
+}
+
+export async function deleteWebhookMessage(webhookId: string, webhookToken: string, messageId: string): Promise<void> {
+  const response = await fetch(
+    `https://discord.com/api/v10/webhooks/${webhookId}/${webhookToken}/messages/${messageId}`,
+    {
+      method: "DELETE"
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Error deleting webhook message: ${response.statusText}`);
+  }
+}

--- a/src/util/types/discord/DiscordTypeExtension.ts
+++ b/src/util/types/discord/DiscordTypeExtension.ts
@@ -42,7 +42,7 @@ export interface WebhookMessageResponse {
   timestamp: string;
   edited_timestamp: string;
   flags: number;
-  components: any[];
+  components: unknown[];
   id: string;
   channel_id: string;
   author: Author;

--- a/src/util/types/discord/DiscordTypeExtension.ts
+++ b/src/util/types/discord/DiscordTypeExtension.ts
@@ -17,7 +17,7 @@ export enum EntitlementType {
   UNKNOWN
 }
 
-export interface Webhook {
+export interface WebhookCreatedResponse {
   id: string;
   type: number;
   guild_id?: string;

--- a/src/util/types/discord/DiscordTypeExtension.ts
+++ b/src/util/types/discord/DiscordTypeExtension.ts
@@ -16,3 +16,18 @@ export enum EntitlementType {
   SUPER_THIRSTY,
   UNKNOWN
 }
+
+export interface Webhook {
+  id: string;
+  type: number;
+  guild_id?: string;
+  channel_id: string;
+  user?: object;
+  name?: string;
+  avatar?: string;
+  token?: string;
+  application_id?: string;
+  source_guild?: object;
+  source_channel?: object;
+  url?: string;
+}

--- a/src/util/types/discord/DiscordTypeExtension.ts
+++ b/src/util/types/discord/DiscordTypeExtension.ts
@@ -31,3 +31,42 @@ export interface Webhook {
   source_channel?: object;
   url?: string;
 }
+
+export interface WebhookMessageResponse {
+  type: number;
+  content: string;
+  mentions: string[];
+  mention_roles: string[];
+  attachments: string[];
+  embeds: Embed[];
+  timestamp: string;
+  edited_timestamp: string;
+  flags: number;
+  components: any[];
+  id: string;
+  channel_id: string;
+  author: Author;
+  pinned: boolean;
+  mention_everyone: boolean;
+  tts: boolean;
+  webhook_id: string;
+}
+
+export interface Embed {
+  type: string;
+  description: string;
+  color: number;
+  content_scan_version: number;
+}
+
+export interface Author {
+  id: string;
+  username: string;
+  avatar: string;
+  discriminator: string;
+  public_flags: number;
+  flags: number;
+  bot: boolean;
+  global_name: string;
+  clan: string;
+}


### PR DESCRIPTION
Fixes #69

Add notifications when the tree is ready to water.

* Add a new command `notificationSettings` in `src/commands/NotificationSettings.ts` to configure the role and channel for notifications.
* Modify `src/commands/Tree.ts` to send a notification to the configured channel and ping the configured role when the tree is ready to water.
* Update `src/index.ts` to register the new `NotificationSettings` command.
* Update the database schema in `src/models/Guild.ts` to include fields for the role ID and channel ID for notifications.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GewoonJaap/grow-a-christmas-tree/issues/69?shareId=2a96357a-4e5a-460a-848e-0d9bbc70d839).