### PR TITLE
Extend ButtonBuilder to support store button

### DIFF
--- a/src/commands/NotificationSettings.ts
+++ b/src/commands/NotificationSettings.ts
@@ -1,4 +1,5 @@
 import {
+  ActionRowBuilder,
   EmbedBuilder,
   ISlashCommand,
   MessageBuilder,
@@ -10,6 +11,7 @@ import {
 } from "interactions.ts";
 import { Guild } from "../models/Guild";
 import { createWebhook } from "../util/discord/DiscordWebhookHelper";
+import { PremiumButtons } from "../util/buttons/PremiumButtons";
 
 const builder = new SlashCommandBuilder("notifications", "Configure the role and channel for notifications.")
   .addBooleanOption(new SlashCommandBooleanOption("enabled", "Turn notification on or off").setRequired(true))
@@ -35,13 +37,19 @@ export class NotificationSettings implements ISlashCommand {
       return ctx.reply(new MessageBuilder().addEmbed(embed).setEphemeral(true));
     }
     if (!ctx.game.hasAiAccess) {
+      const actionBuilder = new ActionRowBuilder();
+      if (!process.env.DEV_MODE) {
+        actionBuilder.addComponents(
+          await ctx.manager.components.createInstance(PremiumButtons.FestiveForestButtonName)
+        );
+      }
       const embed = new EmbedBuilder()
         .setDescription(
           "You have just discovered a premium only feature! Visit the [shop](https://discord.com/application-directory/1050722873569968128/store) or click the bot avatar and buy the [Festive Forest subscription](https://discord.com/application-directory/1050722873569968128/store/1298016263687110697) to gain access."
         )
         .setTitle("Woah there!")
         .setFooter({ text: "Enjoying the bot? Consider supporting us by buying a subscription!" });
-      return ctx.reply(new MessageBuilder().addEmbed(embed).setEphemeral(true));
+      return ctx.reply(new MessageBuilder().addEmbed(embed).addComponents(actionBuilder));
     }
     const role = ctx.options.get("role")?.value as string | undefined;
     const channel = ctx.options.get("channel")?.value as string | undefined;
@@ -95,5 +103,5 @@ export class NotificationSettings implements ISlashCommand {
     }
   };
 
-  public components = [];
+  public components = [PremiumButtons.FestiveForestButton];
 }

--- a/src/commands/Tree.ts
+++ b/src/commands/Tree.ts
@@ -129,7 +129,14 @@ export class Tree implements ISlashCommand {
     ...GrinchHeistMinigame.buttons,
     ...HolidayCookieCountdownMinigame.buttons,
     ...TinselTwisterMinigame.buttons,
-    ...CarolingChoirMinigame.buttons
+    ...CarolingChoirMinigame.buttons,
+    new Button(
+      "tree.store",
+      new ButtonBuilder().setEmoji({ name: "🛒" }).setStyle(6).setSkuId("premium_sku_id"),
+      async (ctx: ButtonContext): Promise<void> => {
+        // Handle store button click
+      }
+    )
   ];
 }
 
@@ -160,7 +167,8 @@ export async function buildTreeDisplayMessage(ctx: SlashCommandContext | ButtonC
   const message = new MessageBuilder().addComponents(
     new ActionRowBuilder().addComponents(
       await ctx.manager.components.createInstance("tree.grow"),
-      await ctx.manager.components.createInstance("tree.refresh")
+      await ctx.manager.components.createInstance("tree.refresh"),
+      await ctx.manager.components.createInstance("tree.store")
     )
   );
 

--- a/src/commands/Tree.ts
+++ b/src/commands/Tree.ts
@@ -24,7 +24,6 @@ import { sendAndDeleteWebhookMessage } from "../util/TreeWateringNotification";
 import { HolidayCookieCountdownMinigame } from "../minigames/HolidayCookieCountdownMinigame";
 import { TinselTwisterMinigame } from "../minigames/TinselTwisterMinigame";
 import { CarolingChoirMinigame } from "../minigames/CarolingChoirMinigame";
-import { PremiumButtons } from "../util/buttons/PremiumButtons";
 
 const MINIGAME_CHANCE = 0.4;
 const MINIGAME_DELAY_SECONDS = 5 * 60;
@@ -130,8 +129,7 @@ export class Tree implements ISlashCommand {
     ...GrinchHeistMinigame.buttons,
     ...HolidayCookieCountdownMinigame.buttons,
     ...TinselTwisterMinigame.buttons,
-    ...CarolingChoirMinigame.buttons,
-    PremiumButtons.FestiveForestButton
+    ...CarolingChoirMinigame.buttons
   ];
 }
 
@@ -163,9 +161,6 @@ export async function buildTreeDisplayMessage(ctx: SlashCommandContext | ButtonC
     await ctx.manager.components.createInstance("tree.grow"),
     await ctx.manager.components.createInstance("tree.refresh")
   );
-  if (!process.env.DEV_MODE) {
-    actionBuilder.addComponents(await ctx.manager.components.createInstance(PremiumButtons.FestiveForestButtonName));
-  }
   const message = new MessageBuilder().addComponents(actionBuilder);
 
   const canBeWateredAt = ctx.game.lastWateredAt + getWateringInterval(ctx.game.size, ctx.game.superThirsty ?? false);

--- a/src/commands/Tree.ts
+++ b/src/commands/Tree.ts
@@ -24,7 +24,6 @@ import { sendAndDeleteWebhookMessage } from "../util/TreeWateringNotification";
 import { HolidayCookieCountdownMinigame } from "../minigames/HolidayCookieCountdownMinigame";
 import { TinselTwisterMinigame } from "../minigames/TinselTwisterMinigame";
 import { CarolingChoirMinigame } from "../minigames/CarolingChoirMinigame";
-import { PremiumButtonStyleTypes } from "../util/types/discord/DiscordTypeExtension";
 
 const MINIGAME_CHANCE = 0.4;
 const MINIGAME_DELAY_SECONDS = 5 * 60;
@@ -135,7 +134,8 @@ export class Tree implements ISlashCommand {
       "tree.store",
       new PremiumButtonBuilder()
         .setEmoji({ name: "🛒" })
-        .setStyle(PremiumButtonStyleTypes.PREMIUM as any)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .setStyle(6 as any)
         .setSkuId("1298016263687110697")
     )
   ];
@@ -165,13 +165,14 @@ export async function buildTreeDisplayMessage(ctx: SlashCommandContext | ButtonC
 
   await updateEntitlementsToGame(ctx);
 
-  const message = new MessageBuilder().addComponents(
-    new ActionRowBuilder().addComponents(
-      await ctx.manager.components.createInstance("tree.grow"),
-      await ctx.manager.components.createInstance("tree.refresh"),
-      await ctx.manager.components.createInstance("tree.store")
-    )
+  const actionBuilder = new ActionRowBuilder().addComponents(
+    await ctx.manager.components.createInstance("tree.grow"),
+    await ctx.manager.components.createInstance("tree.refresh")
   );
+  if (!process.env.DEV_MODE) {
+    actionBuilder.addComponents(await ctx.manager.components.createInstance("tree.store"));
+  }
+  const message = new MessageBuilder().addComponents(actionBuilder);
 
   const canBeWateredAt = ctx.game.lastWateredAt + getWateringInterval(ctx.game.size, ctx.game.superThirsty ?? false);
 

--- a/src/commands/Tree.ts
+++ b/src/commands/Tree.ts
@@ -13,7 +13,7 @@ import {
 import { calculateTreeTierImage, getCurrentTreeTier } from "../util/tree-tier-calculator";
 import { getTreeAge, getWateringInterval } from "../util/watering-inteval";
 import humanizeDuration = require("humanize-duration");
-import { updateEntitlementsToGame } from "../util/discord/DiscordApiExtensions";
+import { PremiumButtonBuilder, updateEntitlementsToGame } from "../util/discord/DiscordApiExtensions";
 import { startRandomMinigame } from "../minigames/MinigameFactory";
 import { SantaPresentMinigame } from "../minigames/SantaPresentMinigame";
 import { HotCocoaMinigame } from "../minigames/HotCocoaMinigame";
@@ -24,6 +24,7 @@ import { sendAndDeleteWebhookMessage } from "../util/TreeWateringNotification";
 import { HolidayCookieCountdownMinigame } from "../minigames/HolidayCookieCountdownMinigame";
 import { TinselTwisterMinigame } from "../minigames/TinselTwisterMinigame";
 import { CarolingChoirMinigame } from "../minigames/CarolingChoirMinigame";
+import { PremiumButtonStyleTypes } from "../util/types/discord/DiscordTypeExtension";
 
 const MINIGAME_CHANCE = 0.4;
 const MINIGAME_DELAY_SECONDS = 5 * 60;
@@ -132,10 +133,10 @@ export class Tree implements ISlashCommand {
     ...CarolingChoirMinigame.buttons,
     new Button(
       "tree.store",
-      new ButtonBuilder().setEmoji({ name: "🛒" }).setStyle(6).setSkuId("premium_sku_id"),
-      async (ctx: ButtonContext): Promise<void> => {
-        // Handle store button click
-      }
+      new PremiumButtonBuilder()
+        .setEmoji({ name: "🛒" })
+        .setStyle(PremiumButtonStyleTypes.PREMIUM as any)
+        .setSkuId("1298016263687110697")
     )
   ];
 }

--- a/src/commands/Tree.ts
+++ b/src/commands/Tree.ts
@@ -13,7 +13,7 @@ import {
 import { calculateTreeTierImage, getCurrentTreeTier } from "../util/tree-tier-calculator";
 import { getTreeAge, getWateringInterval } from "../util/watering-inteval";
 import humanizeDuration = require("humanize-duration");
-import { PremiumButtonBuilder, updateEntitlementsToGame } from "../util/discord/DiscordApiExtensions";
+import { updateEntitlementsToGame } from "../util/discord/DiscordApiExtensions";
 import { startRandomMinigame } from "../minigames/MinigameFactory";
 import { SantaPresentMinigame } from "../minigames/SantaPresentMinigame";
 import { HotCocoaMinigame } from "../minigames/HotCocoaMinigame";
@@ -24,6 +24,7 @@ import { sendAndDeleteWebhookMessage } from "../util/TreeWateringNotification";
 import { HolidayCookieCountdownMinigame } from "../minigames/HolidayCookieCountdownMinigame";
 import { TinselTwisterMinigame } from "../minigames/TinselTwisterMinigame";
 import { CarolingChoirMinigame } from "../minigames/CarolingChoirMinigame";
+import { PremiumButtons } from "../util/buttons/PremiumButtons";
 
 const MINIGAME_CHANCE = 0.4;
 const MINIGAME_DELAY_SECONDS = 5 * 60;
@@ -130,14 +131,7 @@ export class Tree implements ISlashCommand {
     ...HolidayCookieCountdownMinigame.buttons,
     ...TinselTwisterMinigame.buttons,
     ...CarolingChoirMinigame.buttons,
-    new Button(
-      "tree.store",
-      new PremiumButtonBuilder()
-        .setEmoji({ name: "🛒" })
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .setStyle(6 as any)
-        .setSkuId("1298016263687110697")
-    )
+    PremiumButtons.FestiveForestButton
   ];
 }
 
@@ -170,7 +164,7 @@ export async function buildTreeDisplayMessage(ctx: SlashCommandContext | ButtonC
     await ctx.manager.components.createInstance("tree.refresh")
   );
   if (!process.env.DEV_MODE) {
-    actionBuilder.addComponents(await ctx.manager.components.createInstance("tree.store"));
+    actionBuilder.addComponents(await ctx.manager.components.createInstance(PremiumButtons.FestiveForestButtonName));
   }
   const message = new MessageBuilder().addComponents(actionBuilder);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import { Guild, IGuild } from "./models/Guild";
 import { fetchStats } from "./api/stats";
 import { Feedback } from "./commands/Feedback";
 import { startBackupTimer } from "./backup/backup";
-const VERSION = "1.3";
+const VERSION = "1.4";
 
 declare module "interactions.ts" {
   interface BaseInteractionContext {

--- a/src/minigames/CarolingChoirMinigame.ts
+++ b/src/minigames/CarolingChoirMinigame.ts
@@ -126,6 +126,13 @@ export class CarolingChoirMinigame implements Minigame {
       "minigame.carolingchoir.wrongnote-3",
       new ButtonBuilder().setEmoji({ name: "😼" }).setStyle(4),
       CarolingChoirMinigame.handleWrongNoteButton
+    ),
+    new Button(
+      "minigame.carolingchoir.store",
+      new ButtonBuilder().setEmoji({ name: "🛒" }).setStyle(6).setSkuId("premium_sku_id"),
+      async (ctx: ButtonContext): Promise<void> => {
+        // Handle store button click
+      }
     )
   ];
 }

--- a/src/minigames/CarolingChoirMinigame.ts
+++ b/src/minigames/CarolingChoirMinigame.ts
@@ -126,13 +126,6 @@ export class CarolingChoirMinigame implements Minigame {
       "minigame.carolingchoir.wrongnote-3",
       new ButtonBuilder().setEmoji({ name: "😼" }).setStyle(4),
       CarolingChoirMinigame.handleWrongNoteButton
-    ),
-    new Button(
-      "minigame.carolingchoir.store",
-      new ButtonBuilder().setEmoji({ name: "🛒" }).setStyle(6).setSkuId("premium_sku_id"),
-      async (ctx: ButtonContext): Promise<void> => {
-        // Handle store button click
-      }
     )
   ];
 }

--- a/src/util/buttons/PremiumButtons.ts
+++ b/src/util/buttons/PremiumButtons.ts
@@ -1,0 +1,14 @@
+import { Button } from "interactions.ts";
+import { PremiumButtonBuilder } from "../discord/DiscordApiExtensions";
+
+export class PremiumButtons {
+  static FestiveForestButtonName = "festiveforest.premium";
+  static FestiveForestButton = new Button(
+    PremiumButtons.FestiveForestButtonName,
+    new PremiumButtonBuilder()
+      .setEmoji({ name: "🛒" })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .setStyle(6 as any)
+      .setSkuId("1298016263687110697")
+  );
+}

--- a/src/util/discord/DiscordApiExtensions.ts
+++ b/src/util/discord/DiscordApiExtensions.ts
@@ -1,6 +1,7 @@
 import { ButtonContext, SlashCommandContext } from "interactions.ts";
-import { Entitlement, EntitlementType } from "../types/discord/DiscordTypeExtension";
-import { ButtonBuilder as OriginalButtonBuilder, ButtonStyleTypes } from "interactions.ts";
+import { Entitlement, EntitlementType, PremiumButtonStyleTypes } from "../types/discord/DiscordTypeExtension";
+import { ButtonBuilder as OriginalButtonBuilder } from "interactions.ts";
+import { ButtonStyle } from "discord-api-types/v10";
 
 export function getEntitlements(ctx: SlashCommandContext | ButtonContext, withoutExpired = false): Entitlement[] {
   const interaction = ctx.interaction;
@@ -52,7 +53,7 @@ export async function updateEntitlementsToGame(ctx: SlashCommandContext | Button
   await ctx.game.save();
 }
 
-export class ButtonBuilder extends OriginalButtonBuilder {
+export class PremiumButtonBuilder extends OriginalButtonBuilder {
   private sku_id?: string;
 
   public setSkuId(sku_id: string): this {
@@ -60,11 +61,13 @@ export class ButtonBuilder extends OriginalButtonBuilder {
     return this;
   }
 
+  public setStyle(style: ButtonStyle): this {
+    return super.setStyle(style as any);
+  }
+
   public toJSON() {
     const json = super.toJSON();
-    if (this.style === ButtonStyleTypes.PREMIUM && this.sku_id) {
-      json.sku_id = this.sku_id;
-    }
+    if (this.sku_id) (json as unknown as any).sku_id = this.sku_id;
     return json;
   }
 }

--- a/src/util/discord/DiscordApiExtensions.ts
+++ b/src/util/discord/DiscordApiExtensions.ts
@@ -1,5 +1,6 @@
 import { ButtonContext, SlashCommandContext } from "interactions.ts";
 import { Entitlement, EntitlementType } from "../types/discord/DiscordTypeExtension";
+import { ButtonBuilder as OriginalButtonBuilder, ButtonStyleTypes } from "interactions.ts";
 
 export function getEntitlements(ctx: SlashCommandContext | ButtonContext, withoutExpired = false): Entitlement[] {
   const interaction = ctx.interaction;
@@ -49,4 +50,21 @@ export async function updateEntitlementsToGame(ctx: SlashCommandContext | Button
   }
 
   await ctx.game.save();
+}
+
+export class ButtonBuilder extends OriginalButtonBuilder {
+  private sku_id?: string;
+
+  public setSkuId(sku_id: string): this {
+    this.sku_id = sku_id;
+    return this;
+  }
+
+  public toJSON() {
+    const json = super.toJSON();
+    if (this.style === ButtonStyleTypes.PREMIUM && this.sku_id) {
+      json.sku_id = this.sku_id;
+    }
+    return json;
+  }
 }

--- a/src/util/discord/DiscordApiExtensions.ts
+++ b/src/util/discord/DiscordApiExtensions.ts
@@ -1,5 +1,5 @@
 import { ButtonContext, SlashCommandContext } from "interactions.ts";
-import { Entitlement, EntitlementType, PremiumButtonStyleTypes } from "../types/discord/DiscordTypeExtension";
+import { Entitlement, EntitlementType } from "../types/discord/DiscordTypeExtension";
 import { ButtonBuilder as OriginalButtonBuilder } from "interactions.ts";
 import { ButtonStyle } from "discord-api-types/v10";
 
@@ -62,11 +62,13 @@ export class PremiumButtonBuilder extends OriginalButtonBuilder {
   }
 
   public setStyle(style: ButtonStyle): this {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return super.setStyle(style as any);
   }
 
   public toJSON() {
     const json = super.toJSON();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if (this.sku_id) (json as unknown as any).sku_id = this.sku_id;
     return json;
   }

--- a/src/util/types/discord/DiscordTypeExtension.ts
+++ b/src/util/types/discord/DiscordTypeExtension.ts
@@ -70,3 +70,12 @@ export interface Author {
   global_name: string;
   clan: string;
 }
+
+export enum ButtonStyleTypes {
+  PRIMARY = 1,
+  SECONDARY = 2,
+  SUCCESS = 3,
+  DANGER = 4,
+  LINK = 5,
+  PREMIUM = 6
+}

--- a/src/util/types/discord/DiscordTypeExtension.ts
+++ b/src/util/types/discord/DiscordTypeExtension.ts
@@ -71,7 +71,7 @@ export interface Author {
   clan: string;
 }
 
-export enum ButtonStyleTypes {
+export enum PremiumButtonStyleTypes {
   PRIMARY = 1,
   SECONDARY = 2,
   SUCCESS = 3,


### PR DESCRIPTION
Fixes #71

Add support for store button in ButtonBuilder and update relevant files.

* Add new enum value `ButtonStyleTypes.PREMIUM` with id 6 in `src/util/types/discord/DiscordTypeExtension.ts`.
* Update `ButtonBuilder` instances in `src/commands/Tree.ts` and `src/minigames/CarolingChoirMinigame.ts` to support the new style with id 6 and `sku_id` property.
* Create an override of the `ButtonBuilder` in `src/util/discord/DiscordApiExtensions.ts` to handle the new style and `sku_id`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GewoonJaap/grow-a-christmas-tree/issues/71?shareId=1dcbabb3-7b2f-4421-82f0-c4934eeaf185).