### PR TITLE
Combat autoclickers

### DIFF
--- a/src/commands/Tree.ts
+++ b/src/commands/Tree.ts
@@ -14,11 +14,11 @@ import { calculateTreeTierImage, getCurrentTreeTier } from "../util/tree-tier-ca
 import { getTreeAge, getWateringInterval } from "../util/watering-inteval";
 import humanizeDuration = require("humanize-duration");
 import { updateEntitlementsToGame } from "../util/discord/DiscordApiExtensions";
-import { minigameButtons, startRandomMinigame } from "../minigames/MinigameFactory";
+import { minigameButtons, startPenaltyMinigame, startRandomMinigame } from "../minigames/MinigameFactory";
 import { sendAndDeleteWebhookMessage } from "../util/TreeWateringNotification";
 import { calculateGrowthChance, calculateGrowthAmount } from "./Composter";
 import { toFixed } from "../util/helpers/numberHelper";
-import { saveFailedAttempt } from "../util/anti-bot/antiBotHelper";
+import { isUserFlagged, saveFailedAttempt } from "../util/anti-bot/antiBotHelper";
 
 const MINIGAME_CHANCE = 0.4;
 const MINIGAME_DELAY_SECONDS = 5 * 60;
@@ -116,6 +116,11 @@ async function handleTreeGrow(ctx: ButtonContext): Promise<void> {
 
   await ctx.game.save();
 
+  if (await isUserFlagged(ctx)) {
+    const penaltyMinigameStarted = await startPenaltyMinigame(ctx);
+    if (penaltyMinigameStarted) return;
+  }
+
   if (
     process.env.DEV_MODE === "true" ||
     (Math.random() < MINIGAME_CHANCE && ctx.game.lastEventAt + MINIGAME_DELAY_SECONDS < Math.floor(Date.now() / 1000))
@@ -159,7 +164,7 @@ export function disposeActiveTimeouts(
   ctx.timeouts.delete(ctx.interaction?.message?.id ?? "broken");
 }
 
-export function transitionToDefaultTreeView(ctx: ButtonContext, delay = 4000) {
+export function transitionToDefaultTreeView(ctx: ButtonContext | ButtonContext<unknown>, delay = 4000) {
   if (!ctx.game) throw new Error("Game data missing.");
   disposeActiveTimeouts(ctx);
   ctx.timeouts.set(
@@ -181,14 +186,14 @@ export function transitionToDefaultTreeView(ctx: ButtonContext, delay = 4000) {
   );
 }
 
-function getSuperThirstyText(ctx: SlashCommandContext | ButtonContext): string {
+function getSuperThirstyText(ctx: SlashCommandContext | ButtonContext | ButtonContext<unknown>): string {
   if (ctx.game?.superThirsty) {
     return "\n💨This tree is growing faster thanks to the super thirsty upgrade!";
   }
   return "";
 }
 
-function getComposterEffectsText(ctx: SlashCommandContext | ButtonContext): string {
+function getComposterEffectsText(ctx: SlashCommandContext | ButtonContext | ButtonContext<unknown>): string {
   if (ctx.game?.composter) {
     const efficiencyLevel = ctx.game.composter.efficiencyLevel;
     const qualityLevel = ctx.game.composter.qualityLevel;
@@ -206,7 +211,9 @@ function getComposterEffectsText(ctx: SlashCommandContext | ButtonContext): stri
   return "\n🎅 Santa's Magic Composter is at level 0. Use /composter to upgrade it and boost your tree's growth!";
 }
 
-export async function buildTreeDisplayMessage(ctx: SlashCommandContext | ButtonContext): Promise<MessageBuilder> {
+export async function buildTreeDisplayMessage(
+  ctx: SlashCommandContext | ButtonContext | ButtonContext<unknown>
+): Promise<MessageBuilder> {
   if (!ctx.game) throw new Error("Game data missing.");
 
   await updateEntitlementsToGame(ctx);
@@ -283,14 +290,17 @@ export async function buildTreeDisplayMessage(ctx: SlashCommandContext | ButtonC
   return message;
 }
 
-function removeWateringReadyTimeout(ctx: SlashCommandContext | ButtonContext): void {
+function removeWateringReadyTimeout(ctx: SlashCommandContext | ButtonContext | ButtonContext<unknown>): void {
   if (!ctx.game) return;
   const timeout = ctx.timeouts.get(ctx.game.id);
   if (timeout) clearTimeout(timeout);
   ctx.timeouts.delete(ctx.game.id);
 }
 
-function setWateringReadyTimeout(ctx: SlashCommandContext | ButtonContext, timeoutTime: number): void {
+function setWateringReadyTimeout(
+  ctx: SlashCommandContext | ButtonContext | ButtonContext<unknown>,
+  timeoutTime: number
+): void {
   if (!ctx.game) return;
   removeWateringReadyTimeout(ctx);
 
@@ -303,7 +313,7 @@ function setWateringReadyTimeout(ctx: SlashCommandContext | ButtonContext, timeo
   );
 }
 
-async function sendWebhookOnWateringReady(ctx: SlashCommandContext | ButtonContext) {
+async function sendWebhookOnWateringReady(ctx: SlashCommandContext | ButtonContext | ButtonContext<unknown>) {
   if (
     ctx.game &&
     (ctx.game.hasAiAccess || process.env.DEV_MODE) &&

--- a/src/commands/Tree.ts
+++ b/src/commands/Tree.ts
@@ -68,6 +68,7 @@ async function handleTreeGrow(ctx: ButtonContext): Promise<void> {
         .addComponents(actions)
     );
 
+    await logFailedWateringAttempt(ctx, "user watered last");
     transitionToDefaultTreeView(ctx);
 
     return;
@@ -131,7 +132,7 @@ async function handleTreeGrow(ctx: ButtonContext): Promise<void> {
 async function logFailedWateringAttempt(ctx: ButtonContext, failureReason: string): Promise<void> {
   if (!ctx.game) throw new Error("Game data missing.");
 
-  await saveFailedAttempt(ctx.user.id, ctx.game.id, "watering", failureReason);
+  await saveFailedAttempt(ctx, "watering", failureReason);
 }
 
 function applyGrowthBoost(ctx: ButtonContext): void {

--- a/src/commands/Tree.ts
+++ b/src/commands/Tree.ts
@@ -18,7 +18,7 @@ import { minigameButtons, startRandomMinigame } from "../minigames/MinigameFacto
 import { sendAndDeleteWebhookMessage } from "../util/TreeWateringNotification";
 import { calculateGrowthChance, calculateGrowthAmount } from "./Composter";
 import { toFixed } from "../util/helpers/numberHelper";
-import { FailedAttempt } from "../models/FailedAttempt";
+import { saveFailedAttempt } from "../util/anti-bot/antiBotHelper";
 
 const MINIGAME_CHANCE = 0.4;
 const MINIGAME_DELAY_SECONDS = 5 * 60;
@@ -131,15 +131,7 @@ async function handleTreeGrow(ctx: ButtonContext): Promise<void> {
 async function logFailedWateringAttempt(ctx: ButtonContext, failureReason: string): Promise<void> {
   if (!ctx.game) throw new Error("Game data missing.");
 
-  const failedAttempt = new FailedAttempt({
-    userId: ctx.user.id,
-    guildId: ctx.game.id,
-    attemptType: "watering",
-    failureReason,
-    timestamp: new Date()
-  });
-
-  await failedAttempt.save();
+  await saveFailedAttempt(ctx.user.id, ctx.game.id, "watering", failureReason);
 }
 
 function applyGrowthBoost(ctx: ButtonContext): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,8 +38,9 @@ import { startBackupTimer } from "./backup/backup";
 import { WebhookEventType } from "./util/types/discord/DiscordTypeExtension";
 import { handleEntitlementCreate } from "./util/discord/DiscordWebhookEvents";
 import { unleash } from "./util/unleash/UnleashHelper";
-import { FailedAttempt } from "./models/FailedAttempt";
-const VERSION = "1.6";
+import { flagPotentialAutoClickers } from "./util/anti-bot/antiBotHelper";
+import { startAntiBotCleanupTimer } from "./util/anti-bot/antiBotCleanupTimer";
+const VERSION = "1.7";
 
 unleash.on("ready", console.log.bind(console, "Unleash ready"));
 
@@ -86,6 +87,7 @@ if (keys.some((key) => !(key in process.env))) {
           game = await Guild.findOne({ id: ctx.interaction.guild_id });
 
           if (game) await game.populate("contributors");
+          flagPotentialAutoClickers(ctx.user.id, ctx.interaction.guild_id);
         } catch (err) {
           console.error(err);
 
@@ -257,25 +259,4 @@ if (keys.some((key) => !(key in process.env))) {
 console.log(`Grow a christmas tree - V${VERSION}`);
 
 startBackupTimer();
-
-async function checkFailedAttempts(userId: string, guildId: string, timeFrame: number): Promise<number> {
-  const now = new Date();
-  const startTime = new Date(now.getTime() - timeFrame);
-
-  const failedAttempts = await FailedAttempt.countDocuments({
-    userId,
-    guildId,
-    timestamp: { $gte: startTime, $lte: now }
-  });
-
-  return failedAttempts;
-}
-
-async function flagPotentialAutoClickers(userId: string, guildId: string, threshold: number, timeFrame: number): Promise<void> {
-  const failedAttempts = await checkFailedAttempts(userId, guildId, timeFrame);
-
-  if (failedAttempts > threshold) {
-    console.log(`User ${userId} in guild ${guildId} flagged as potential auto-clicker.`);
-    // Add your logic to handle flagged users here, such as logging or applying penalties.
-  }
-}
+startAntiBotCleanupTimer();

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   InteractionHandlerTimedOut,
   PingContext,
   SimpleError,
+  SlashCommandContext,
   UnauthorizedInteraction,
   UnknownApplicationCommandType,
   UnknownComponentType,
@@ -87,7 +88,6 @@ if (keys.some((key) => !(key in process.env))) {
           game = await Guild.findOne({ id: ctx.interaction.guild_id });
 
           if (game) await game.populate("contributors");
-          flagPotentialAutoClickers(ctx.user.id, ctx.interaction.guild_id);
         } catch (err) {
           console.error(err);
 
@@ -102,6 +102,11 @@ if (keys.some((key) => !(key in process.env))) {
 
         ctx.decorate("game", game);
         ctx.decorate("timeouts", timeouts);
+        try {
+          flagPotentialAutoClickers(ctx as SlashCommandContext);
+        } catch (err) {
+          console.error(err);
+        }
       }
     }
   });

--- a/src/minigames/CarolingChoirMinigame.ts
+++ b/src/minigames/CarolingChoirMinigame.ts
@@ -61,6 +61,12 @@ export class CarolingChoirMinigame implements Minigame {
 
     const timeoutId = setTimeout(async () => {
       disposeActiveTimeouts(ctx);
+      await minigameFinished(ctx as ButtonContext, {
+        success: false,
+        difficulty: 1,
+        maxDuration: CAROLING_CHOIR_MINIGAME_MAX_DURATION,
+        failureReason: "Timeout"
+      });
       await ctx.edit(await buildTreeDisplayMessage(ctx as ButtonContext));
     }, CAROLING_CHOIR_MINIGAME_MAX_DURATION);
     disposeActiveTimeouts(ctx);
@@ -80,7 +86,11 @@ export class CarolingChoirMinigame implements Minigame {
 
     transitionToDefaultTreeView(ctx as ButtonContext);
 
-    await minigameFinished(ctx as ButtonContext, true, this.maxStages, CAROLING_CHOIR_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx as ButtonContext, {
+      success: true,
+      difficulty: 1,
+      maxDuration: CAROLING_CHOIR_MINIGAME_MAX_DURATION
+    });
   }
 
   private static async handleNoteButton(ctx: ButtonContext<CarolingChoirButtonState>): Promise<void> {
@@ -103,7 +113,12 @@ export class CarolingChoirMinigame implements Minigame {
 
     transitionToDefaultTreeView(ctx as ButtonContext);
 
-    await minigameFinished(ctx as ButtonContext, false, 0, CAROLING_CHOIR_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx as ButtonContext, {
+      success: false,
+      difficulty: 1,
+      maxDuration: CAROLING_CHOIR_MINIGAME_MAX_DURATION,
+      failureReason: "Wrong button"
+    });
   }
 
   public static buttons = [

--- a/src/minigames/GiftUnwrappingMinigame.ts
+++ b/src/minigames/GiftUnwrappingMinigame.ts
@@ -40,6 +40,12 @@ export class GiftUnwrappingMinigame implements Minigame {
 
     const timeoutId = setTimeout(async () => {
       disposeActiveTimeouts(ctx);
+      await minigameFinished(ctx, {
+        success: false,
+        difficulty: 1,
+        maxDuration: GIFT_UNWRAPPING_MINIGAME_MAX_DURATION,
+        failureReason: "Timeout"
+      });
       await ctx.edit(await buildTreeDisplayMessage(ctx));
     }, GIFT_UNWRAPPING_MINIGAME_MAX_DURATION);
     disposeActiveTimeouts(ctx);
@@ -76,7 +82,7 @@ export class GiftUnwrappingMinigame implements Minigame {
 
     transitionToDefaultTreeView(ctx);
 
-    await minigameFinished(ctx, true, 1, GIFT_UNWRAPPING_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: GIFT_UNWRAPPING_MINIGAME_MAX_DURATION });
   }
 
   private static async handleEmptyBoxButton(ctx: ButtonContext): Promise<void> {
@@ -91,7 +97,12 @@ export class GiftUnwrappingMinigame implements Minigame {
 
     transitionToDefaultTreeView(ctx);
 
-    await minigameFinished(ctx, false, 1, GIFT_UNWRAPPING_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx, {
+      success: false,
+      difficulty: 1,
+      maxDuration: GIFT_UNWRAPPING_MINIGAME_MAX_DURATION,
+      failureReason: "Wrong button"
+    });
   }
 
   public static buttons = [

--- a/src/minigames/GrinchHeistMinigame.ts
+++ b/src/minigames/GrinchHeistMinigame.ts
@@ -65,14 +65,24 @@ export class GrinchHeistMinigame implements Minigame {
       );
 
     if (isTimeout) {
+      await minigameFinished(ctx, {
+        success: false,
+        difficulty: 1,
+        maxDuration: GRINCH_HEIST_MINIGAME_MAX_DURATION,
+        failureReason: "Timeout"
+      });
       await ctx.edit(new MessageBuilder().addEmbed(embed).setComponents([]));
     } else {
+      await minigameFinished(ctx, {
+        success: false,
+        difficulty: 1,
+        maxDuration: GRINCH_HEIST_MINIGAME_MAX_DURATION,
+        failureReason: "Wrong button"
+      });
       await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
     }
 
     transitionToDefaultTreeView(ctx);
-
-    await minigameFinished(ctx, false, 1, GRINCH_HEIST_MINIGAME_MAX_DURATION);
   }
 
   public static buttons = [
@@ -97,7 +107,7 @@ export class GrinchHeistMinigame implements Minigame {
 
         transitionToDefaultTreeView(ctx);
 
-        await minigameFinished(ctx, true, 1, GRINCH_HEIST_MINIGAME_MAX_DURATION);
+        await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: GRINCH_HEIST_MINIGAME_MAX_DURATION });
       }
     ),
     new Button(

--- a/src/minigames/GrinchHeistMinigame.ts
+++ b/src/minigames/GrinchHeistMinigame.ts
@@ -4,8 +4,13 @@ import { disposeActiveTimeouts, transitionToDefaultTreeView } from "../commands/
 import { Minigame, MinigameConfig } from "../util/types/minigame/MinigameType";
 import { getPremiumUpsellMessage, minigameFinished } from "./MinigameFactory";
 import { toFixed } from "../util/helpers/numberHelper";
+import { getRandomButtonStyle } from "../util/discord/DiscordApiExtensions";
 
 const GRINCH_HEIST_MINIGAME_MAX_DURATION = 10 * 1000;
+
+type GrinchHeistButtonState = {
+  isPenalty: boolean;
+};
 
 export class GrinchHeistMinigame implements Minigame {
   config: MinigameConfig = {
@@ -18,7 +23,7 @@ export class GrinchHeistMinigame implements Minigame {
     "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/grinch-heist/grinch-heist-3.jpg"
   ];
 
-  async start(ctx: ButtonContext): Promise<void> {
+  async start(ctx: ButtonContext, isPenalty = false): Promise<void> {
     const embed = new EmbedBuilder()
       .setTitle("Grinch Heist!")
       .setDescription(`Click the tree to save it from the Grinch. Avoid the Grinch!${getPremiumUpsellMessage(ctx)}`)
@@ -28,10 +33,10 @@ export class GrinchHeistMinigame implements Minigame {
       });
 
     const buttons = [
-      await ctx.manager.components.createInstance("minigame.grinchheist.tree"),
-      await ctx.manager.components.createInstance("minigame.grinchheist.grinch-1"),
-      await ctx.manager.components.createInstance("minigame.grinchheist.grinch-2"),
-      await ctx.manager.components.createInstance("minigame.grinchheist.grinch-3")
+      await ctx.manager.components.createInstance("minigame.grinchheist.tree", { isPenalty }),
+      await ctx.manager.components.createInstance("minigame.grinchheist.grinch-1", { isPenalty }),
+      await ctx.manager.components.createInstance("minigame.grinchheist.grinch-2", { isPenalty }),
+      await ctx.manager.components.createInstance("minigame.grinchheist.grinch-3", { isPenalty })
     ];
 
     shuffleArray(buttons);
@@ -49,11 +54,17 @@ export class GrinchHeistMinigame implements Minigame {
     ctx.timeouts.set(ctx.interaction.message.id, timeoutId);
   }
 
-  private static async handleGrinchButton(ctx: ButtonContext, isTimeout = false): Promise<void> {
+  private static async handleGrinchButton(
+    ctx: ButtonContext<GrinchHeistButtonState>,
+    isTimeout = false
+  ): Promise<void> {
     disposeActiveTimeouts(ctx);
 
     if (!ctx.game) throw new Error("Game data missing.");
-    const randomLoss = Math.floor(Math.random() * Math.min(5, Math.floor(ctx.game.size * 0.1))) + 1;
+    let randomLoss = Math.floor(Math.random() * Math.min(5, Math.floor(ctx.game.size * 0.1))) + 1;
+    if (ctx.state?.isPenalty) {
+      randomLoss += 5;
+    }
     ctx.game.size = toFixed(Math.max(0, ctx.game.size - randomLoss), 2);
     await ctx.game.save();
 
@@ -88,8 +99,8 @@ export class GrinchHeistMinigame implements Minigame {
   public static buttons = [
     new Button(
       "minigame.grinchheist.tree",
-      new ButtonBuilder().setEmoji({ name: "🎄" }).setStyle(1),
-      async (ctx: ButtonContext): Promise<void> => {
+      new ButtonBuilder().setEmoji({ name: "🎄" }).setStyle(getRandomButtonStyle()),
+      async (ctx: ButtonContext<GrinchHeistButtonState>): Promise<void> => {
         disposeActiveTimeouts(ctx);
 
         if (!ctx.game) throw new Error("Game data missing.");
@@ -98,7 +109,7 @@ export class GrinchHeistMinigame implements Minigame {
 
         const embed = new EmbedBuilder()
           .setTitle(ctx.game.name)
-          .setDescription("You saved the tree! Your tree grew 1ft taller!")
+          .setDescription(`You saved the tree!${ctx.state?.isPenalty ? "" : " Your tree grew 1ft taller!"}`)
           .setImage(
             "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/grinch-heist/grinch-tree-saved-1.jpg"
           );
@@ -107,27 +118,32 @@ export class GrinchHeistMinigame implements Minigame {
 
         transitionToDefaultTreeView(ctx);
 
-        await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: GRINCH_HEIST_MINIGAME_MAX_DURATION });
+        await minigameFinished(ctx, {
+          success: true,
+          difficulty: 1,
+          maxDuration: GRINCH_HEIST_MINIGAME_MAX_DURATION,
+          penalty: ctx.state?.isPenalty ?? false
+        });
       }
     ),
     new Button(
       "minigame.grinchheist.grinch-1",
-      new ButtonBuilder().setEmoji({ name: "😈" }).setStyle(4),
-      async (ctx: ButtonContext): Promise<void> => {
+      new ButtonBuilder().setEmoji({ name: "😈" }).setStyle(getRandomButtonStyle()),
+      async (ctx: ButtonContext<GrinchHeistButtonState>): Promise<void> => {
         GrinchHeistMinigame.handleGrinchButton(ctx, false);
       }
     ),
     new Button(
       "minigame.grinchheist.grinch-2",
-      new ButtonBuilder().setEmoji({ name: "🎃" }).setStyle(4),
-      async (ctx: ButtonContext): Promise<void> => {
+      new ButtonBuilder().setEmoji({ name: "🎃" }).setStyle(getRandomButtonStyle()),
+      async (ctx: ButtonContext<GrinchHeistButtonState>): Promise<void> => {
         GrinchHeistMinigame.handleGrinchButton(ctx, false);
       }
     ),
     new Button(
       "minigame.grinchheist.grinch-3",
-      new ButtonBuilder().setEmoji({ name: "👽" }).setStyle(4),
-      async (ctx: ButtonContext): Promise<void> => {
+      new ButtonBuilder().setEmoji({ name: "👽" }).setStyle(getRandomButtonStyle()),
+      async (ctx: ButtonContext<GrinchHeistButtonState>): Promise<void> => {
         GrinchHeistMinigame.handleGrinchButton(ctx, false);
       }
     )

--- a/src/minigames/HolidayCookieCountdownMinigame.ts
+++ b/src/minigames/HolidayCookieCountdownMinigame.ts
@@ -79,7 +79,11 @@ export class HolidayCookieCountdownMinigame implements Minigame {
 
     await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
 
-    await minigameFinished(ctx as ButtonContext, true, 1, HOLIDAY_COOKIE_COUNTDOWN_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx, {
+      success: true,
+      difficulty: 1,
+      maxDuration: HOLIDAY_COOKIE_COUNTDOWN_MINIGAME_MAX_DURATION
+    });
 
     transitionToDefaultTreeView(ctx as ButtonContext);
   }
@@ -103,12 +107,22 @@ export class HolidayCookieCountdownMinigame implements Minigame {
       .setTitle(ctx.game.name)
       .setDescription("You missed the cookie. Better luck next time!");
 
-    await minigameFinished(ctx as ButtonContext, false, 1, HOLIDAY_COOKIE_COUNTDOWN_MINIGAME_MAX_DURATION);
-
     if (isTimeout) {
       await ctx.edit(new MessageBuilder().addEmbed(embed).setComponents([]));
+      await minigameFinished(ctx, {
+        success: false,
+        difficulty: 1,
+        maxDuration: HOLIDAY_COOKIE_COUNTDOWN_MINIGAME_MAX_DURATION,
+        failureReason: "Timeout"
+      });
     } else {
       await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+      await minigameFinished(ctx, {
+        success: false,
+        difficulty: 1,
+        maxDuration: HOLIDAY_COOKIE_COUNTDOWN_MINIGAME_MAX_DURATION,
+        failureReason: "Wrong button"
+      });
     }
 
     transitionToDefaultTreeView(ctx as ButtonContext);

--- a/src/minigames/HotCocoaMinigame.ts
+++ b/src/minigames/HotCocoaMinigame.ts
@@ -41,6 +41,13 @@ export class HotCocoaMinigame implements Minigame {
 
     const timeoutId = setTimeout(async () => {
       disposeActiveTimeouts(ctx);
+      await minigameFinished(ctx, {
+        success: false,
+        difficulty: 1,
+        maxDuration: HOT_COCOA_MINIGAME_MAX_DURATION,
+        failureReason: "Timeout"
+      });
+
       await ctx.edit(await buildTreeDisplayMessage(ctx));
     }, HOT_COCOA_MINIGAME_MAX_DURATION);
     disposeActiveTimeouts(ctx);
@@ -58,7 +65,12 @@ export class HotCocoaMinigame implements Minigame {
 
     ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
 
-    await minigameFinished(ctx as ButtonContext, false, 1, HOT_COCOA_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx, {
+      success: false,
+      difficulty: 1,
+      maxDuration: HOT_COCOA_MINIGAME_MAX_DURATION,
+      failureReason: "Wrong button"
+    });
 
     transitionToDefaultTreeView(ctx);
   }
@@ -80,7 +92,8 @@ export class HotCocoaMinigame implements Minigame {
           .setDescription(`This hot cocoa is delicious! Your tree has grown 1ft!`);
 
         ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
-        await minigameFinished(ctx as ButtonContext, true, 1, HOT_COCOA_MINIGAME_MAX_DURATION);
+        await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: HOT_COCOA_MINIGAME_MAX_DURATION });
+
         transitionToDefaultTreeView(ctx);
       }
     ),

--- a/src/minigames/MinigameFactory.ts
+++ b/src/minigames/MinigameFactory.ts
@@ -175,5 +175,5 @@ export async function logFailedMinigameAttempt(
 ): Promise<void> {
   if (!ctx.game) throw new Error("Game data missing.");
 
-  await saveFailedAttempt(ctx.user.id, ctx.game.id, "minigame", failureReason);
+  await saveFailedAttempt(ctx, "minigame", failureReason);
 }

--- a/src/minigames/MinigameFactory.ts
+++ b/src/minigames/MinigameFactory.ts
@@ -18,6 +18,7 @@ import { EarthDayCleanupMinigame } from "./specialDays/EarthDayCleanupMinigame";
 import { getRandomElement } from "../util/helpers/arrayHelper";
 
 import { WalletHelper } from "../util/wallet/WalletHelper";
+import { FailedAttempt } from "../models/FailedAttempt";
 
 export const minigameButtons = [
   ...SantaPresentMinigame.buttons,
@@ -158,4 +159,18 @@ export async function minigameFinished(
   maxDuration: number
 ): Promise<void> {
   await handleMinigameCoins(ctx, success, difficulty, maxDuration);
+}
+
+export async function logFailedMinigameAttempt(ctx: ButtonContext, failureReason: string): Promise<void> {
+  if (!ctx.game) throw new Error("Game data missing.");
+
+  const failedAttempt = new FailedAttempt({
+    userId: ctx.user.id,
+    guildId: ctx.game.id,
+    attemptType: "minigame",
+    failureReason,
+    timestamp: new Date()
+  });
+
+  await failedAttempt.save();
 }

--- a/src/minigames/SantaPresentMinigame.ts
+++ b/src/minigames/SantaPresentMinigame.ts
@@ -38,6 +38,12 @@ export class SantaPresentMinigame implements Minigame {
 
     const timeoutId = setTimeout(async () => {
       disposeActiveTimeouts(ctx);
+      await minigameFinished(ctx, {
+        success: false,
+        difficulty: 1,
+        maxDuration: SANTA_MINIGAME_MAX_DURATION,
+        failureReason: "Timeout"
+      });
       await ctx.edit(await buildTreeDisplayMessage(ctx));
     }, SANTA_MINIGAME_MAX_DURATION);
     disposeActiveTimeouts(ctx);
@@ -60,7 +66,7 @@ export class SantaPresentMinigame implements Minigame {
 
     ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
 
-    await minigameFinished(ctx as ButtonContext, true, 1, SANTA_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: SANTA_MINIGAME_MAX_DURATION });
 
     transitionToDefaultTreeView(ctx);
   }
@@ -74,7 +80,12 @@ export class SantaPresentMinigame implements Minigame {
 
     ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
 
-    await minigameFinished(ctx as ButtonContext, false, 1, SANTA_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx, {
+      success: false,
+      difficulty: 1,
+      maxDuration: SANTA_MINIGAME_MAX_DURATION,
+      failureReason: "Wrong button"
+    });
 
     transitionToDefaultTreeView(ctx);
   }

--- a/src/minigames/SnowballFightMinigame.ts
+++ b/src/minigames/SnowballFightMinigame.ts
@@ -1,6 +1,6 @@
 import { ButtonContext, EmbedBuilder, MessageBuilder, ActionRowBuilder, Button, ButtonBuilder } from "interactions.ts";
 import { shuffleArray } from "../util/helpers/arrayHelper";
-import { buildTreeDisplayMessage, disposeActiveTimeouts, transitionToDefaultTreeView } from "../commands/Tree";
+import { disposeActiveTimeouts, transitionToDefaultTreeView } from "../commands/Tree";
 import { Minigame, MinigameConfig } from "../util/types/minigame/MinigameType";
 import { getPremiumUpsellMessage, minigameFinished } from "./MinigameFactory";
 

--- a/src/minigames/SnowballFightMinigame.ts
+++ b/src/minigames/SnowballFightMinigame.ts
@@ -41,7 +41,7 @@ export class SnowballFightMinigame implements Minigame {
 
     const timeoutId = setTimeout(async () => {
       disposeActiveTimeouts(ctx);
-      await ctx.edit(await buildTreeDisplayMessage(ctx));
+      SnowballFightMinigame.handleMissButton(ctx, true);
     }, SNOWBALL_FIGHT_MINIGAME_MAX_DURATION);
     disposeActiveTimeouts(ctx);
     ctx.timeouts.set(ctx.interaction.message.id, timeoutId);
@@ -67,7 +67,7 @@ export class SnowballFightMinigame implements Minigame {
     const embed = new EmbedBuilder().setTitle(ctx.game.name).setDescription(message);
     await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
 
-    await minigameFinished(ctx as ButtonContext, true, 1, SNOWBALL_FIGHT_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: SNOWBALL_FIGHT_MINIGAME_MAX_DURATION });
 
     transitionToDefaultTreeView(ctx);
   }
@@ -82,12 +82,22 @@ export class SnowballFightMinigame implements Minigame {
       .setDescription(`You missed the target. Better luck next time!`);
 
     if (isTimeout) {
+      await minigameFinished(ctx, {
+        success: true,
+        difficulty: 1,
+        maxDuration: SNOWBALL_FIGHT_MINIGAME_MAX_DURATION,
+        failureReason: "Timeout"
+      });
       await ctx.edit(new MessageBuilder().addEmbed(embed).setComponents([]));
     } else {
+      await minigameFinished(ctx, {
+        success: true,
+        difficulty: 1,
+        maxDuration: SNOWBALL_FIGHT_MINIGAME_MAX_DURATION,
+        failureReason: "Wrong button"
+      });
       await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
     }
-
-    await minigameFinished(ctx as ButtonContext, false, 1, SNOWBALL_FIGHT_MINIGAME_MAX_DURATION);
 
     transitionToDefaultTreeView(ctx);
   }

--- a/src/minigames/TinselTwisterMinigame.ts
+++ b/src/minigames/TinselTwisterMinigame.ts
@@ -62,6 +62,12 @@ export class TinselTwisterMinigame implements Minigame {
 
     const timeoutId = setTimeout(async () => {
       disposeActiveTimeouts(ctx);
+      await minigameFinished(ctx, {
+        success: false,
+        difficulty: 1,
+        maxDuration: TINSEL_TWISTER_MINIGAME_MAX_DURATION,
+        failureReason: "Timeout"
+      });
       await ctx.edit(await buildTreeDisplayMessage(ctx as ButtonContext));
     }, TINSEL_TWISTER_MINIGAME_MAX_DURATION);
     disposeActiveTimeouts(ctx);
@@ -78,7 +84,7 @@ export class TinselTwisterMinigame implements Minigame {
       .setDescription(`You completed the Tinsel Twister! Your tree has grown 1ft!`);
 
     await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
-    await minigameFinished(ctx as ButtonContext, true, 1, TINSEL_TWISTER_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: TINSEL_TWISTER_MINIGAME_MAX_DURATION });
     transitionToDefaultTreeView(ctx as ButtonContext);
   }
 
@@ -108,7 +114,12 @@ export class TinselTwisterMinigame implements Minigame {
       await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
     }
 
-    await minigameFinished(ctx as ButtonContext, false, 1, TINSEL_TWISTER_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx, {
+      success: false,
+      difficulty: 1,
+      maxDuration: TINSEL_TWISTER_MINIGAME_MAX_DURATION,
+      failureReason: "Wrong button"
+    });
     transitionToDefaultTreeView(ctx as ButtonContext);
   }
 

--- a/src/minigames/specialDays/EarthDayCleanupMinigame.ts
+++ b/src/minigames/specialDays/EarthDayCleanupMinigame.ts
@@ -38,6 +38,12 @@ export class EarthDayCleanupMinigame implements Minigame {
 
     const timeoutId = setTimeout(async () => {
       disposeActiveTimeouts(ctx);
+      await minigameFinished(ctx, {
+        success: false,
+        difficulty: 1,
+        maxDuration: EARTH_DAY_CLEANUP_MINIGAME_MAX_DURATION,
+        failureReason: "Timeout"
+      });
       await ctx.edit(await buildTreeDisplayMessage(ctx));
     }, EARTH_DAY_CLEANUP_MINIGAME_MAX_DURATION);
     disposeActiveTimeouts(ctx);
@@ -60,7 +66,7 @@ export class EarthDayCleanupMinigame implements Minigame {
 
     ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
 
-    minigameFinished(ctx as ButtonContext, true, 1, EARTH_DAY_CLEANUP_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: EARTH_DAY_CLEANUP_MINIGAME_MAX_DURATION });
 
     transitionToDefaultTreeView(ctx);
   }
@@ -75,7 +81,12 @@ export class EarthDayCleanupMinigame implements Minigame {
 
     ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
 
-    minigameFinished(ctx as ButtonContext, false, 1, EARTH_DAY_CLEANUP_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx, {
+      success: false,
+      difficulty: 1,
+      maxDuration: EARTH_DAY_CLEANUP_MINIGAME_MAX_DURATION,
+      failureReason: "Wrong button"
+    });
 
     transitionToDefaultTreeView(ctx);
   }

--- a/src/minigames/specialDays/FireworksShowMinigame.ts
+++ b/src/minigames/specialDays/FireworksShowMinigame.ts
@@ -38,6 +38,12 @@ export class FireworksShowMinigame implements Minigame {
 
     const timeoutId = setTimeout(async () => {
       disposeActiveTimeouts(ctx);
+      await minigameFinished(ctx, {
+        success: false,
+        difficulty: 1,
+        maxDuration: FIREWORKS_SHOW_MINIGAME_MAX_DURATION,
+        failureReason: "Timeout"
+      });
       await ctx.edit(await buildTreeDisplayMessage(ctx));
     }, FIREWORKS_SHOW_MINIGAME_MAX_DURATION);
     disposeActiveTimeouts(ctx);
@@ -59,7 +65,7 @@ export class FireworksShowMinigame implements Minigame {
       );
 
     ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
-    minigameFinished(ctx as ButtonContext, true, 1, FIREWORKS_SHOW_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: FIREWORKS_SHOW_MINIGAME_MAX_DURATION });
     transitionToDefaultTreeView(ctx);
   }
 
@@ -72,7 +78,12 @@ export class FireworksShowMinigame implements Minigame {
       .setDescription("You missed the fireworks. Better luck next time!");
 
     ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
-    minigameFinished(ctx as ButtonContext, false, 1, FIREWORKS_SHOW_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx, {
+      success: false,
+      difficulty: 1,
+      maxDuration: FIREWORKS_SHOW_MINIGAME_MAX_DURATION,
+      failureReason: "Wrong button"
+    });
     transitionToDefaultTreeView(ctx);
   }
 

--- a/src/minigames/specialDays/HeartCollectionMinigame.ts
+++ b/src/minigames/specialDays/HeartCollectionMinigame.ts
@@ -38,6 +38,12 @@ export class HeartCollectionMinigame implements Minigame {
 
     const timeoutId = setTimeout(async () => {
       disposeActiveTimeouts(ctx);
+      await minigameFinished(ctx, {
+        success: false,
+        difficulty: 1,
+        maxDuration: HEART_COLLECTION_MINIGAME_MAX_DURATION,
+        failureReason: "Timeout"
+      });
       await ctx.edit(await buildTreeDisplayMessage(ctx));
     }, HEART_COLLECTION_MINIGAME_MAX_DURATION);
     disposeActiveTimeouts(ctx);
@@ -59,7 +65,7 @@ export class HeartCollectionMinigame implements Minigame {
       );
 
     ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
-    minigameFinished(ctx as ButtonContext, true, 1, HEART_COLLECTION_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: HEART_COLLECTION_MINIGAME_MAX_DURATION });
     transitionToDefaultTreeView(ctx);
   }
 
@@ -72,7 +78,12 @@ export class HeartCollectionMinigame implements Minigame {
       .setDescription("You missed the hearts. Better luck next time!");
 
     ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
-    minigameFinished(ctx as ButtonContext, false, 1, HEART_COLLECTION_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx, {
+      success: false,
+      difficulty: 1,
+      maxDuration: HEART_COLLECTION_MINIGAME_MAX_DURATION,
+      failureReason: "Wrong button"
+    });
     transitionToDefaultTreeView(ctx);
   }
 

--- a/src/minigames/specialDays/PumpkinHuntMinigame.ts
+++ b/src/minigames/specialDays/PumpkinHuntMinigame.ts
@@ -38,6 +38,12 @@ export class PumpkinHuntMinigame implements Minigame {
 
     const timeoutId = setTimeout(async () => {
       disposeActiveTimeouts(ctx);
+      await minigameFinished(ctx, {
+        success: false,
+        difficulty: 1,
+        maxDuration: PUMPKIN_HUNT_MINIGAME_MAX_DURATION,
+        failureReason: "Timeout"
+      });
       await ctx.edit(await buildTreeDisplayMessage(ctx));
     }, PUMPKIN_HUNT_MINIGAME_MAX_DURATION);
     disposeActiveTimeouts(ctx);
@@ -57,7 +63,7 @@ export class PumpkinHuntMinigame implements Minigame {
       .setImage("https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/halloween/halloween-2.jpg");
 
     ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
-    minigameFinished(ctx as ButtonContext, true, 1, PUMPKIN_HUNT_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: PUMPKIN_HUNT_MINIGAME_MAX_DURATION });
     transitionToDefaultTreeView(ctx);
   }
 
@@ -70,7 +76,12 @@ export class PumpkinHuntMinigame implements Minigame {
       .setDescription("You missed the pumpkins. Better luck next time!");
 
     ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
-    minigameFinished(ctx as ButtonContext, false, 1, PUMPKIN_HUNT_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx, {
+      success: false,
+      difficulty: 1,
+      maxDuration: PUMPKIN_HUNT_MINIGAME_MAX_DURATION,
+      failureReason: "Wrong button"
+    });
     transitionToDefaultTreeView(ctx);
   }
 

--- a/src/minigames/specialDays/StPatricksDayTreasureHuntMinigame.ts
+++ b/src/minigames/specialDays/StPatricksDayTreasureHuntMinigame.ts
@@ -38,6 +38,12 @@ export class StPatricksDayTreasureHuntMinigame implements Minigame {
 
     const timeoutId = setTimeout(async () => {
       disposeActiveTimeouts(ctx);
+      await minigameFinished(ctx, {
+        success: false,
+        difficulty: 1,
+        maxDuration: STPATRICKS_TREASURE_HUNT_MINIGAME_MAX_DURATION,
+        failureReason: "Timeout"
+      });
       await ctx.edit(await buildTreeDisplayMessage(ctx));
     }, STPATRICKS_TREASURE_HUNT_MINIGAME_MAX_DURATION);
     disposeActiveTimeouts(ctx);
@@ -59,7 +65,11 @@ export class StPatricksDayTreasureHuntMinigame implements Minigame {
       );
 
     ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
-    minigameFinished(ctx as ButtonContext, true, 1, STPATRICKS_TREASURE_HUNT_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx, {
+      success: true,
+      difficulty: 1,
+      maxDuration: STPATRICKS_TREASURE_HUNT_MINIGAME_MAX_DURATION
+    });
     transitionToDefaultTreeView(ctx);
   }
 
@@ -72,7 +82,12 @@ export class StPatricksDayTreasureHuntMinigame implements Minigame {
       .setDescription("You missed the treasures. Better luck next time!");
 
     ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
-    minigameFinished(ctx as ButtonContext, false, 1, STPATRICKS_TREASURE_HUNT_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx, {
+      success: false,
+      difficulty: 1,
+      maxDuration: STPATRICKS_TREASURE_HUNT_MINIGAME_MAX_DURATION,
+      failureReason: "Wrong button"
+    });
     transitionToDefaultTreeView(ctx);
   }
 

--- a/src/minigames/specialDays/ThanksgivingFeastMinigame.ts
+++ b/src/minigames/specialDays/ThanksgivingFeastMinigame.ts
@@ -40,6 +40,12 @@ export class ThanksgivingFeastMinigame implements Minigame {
 
     const timeoutId = setTimeout(async () => {
       disposeActiveTimeouts(ctx);
+      await minigameFinished(ctx, {
+        success: false,
+        difficulty: 1,
+        maxDuration: THANKSGIVING_FEAST_MINIGAME_MAX_DURATION,
+        failureReason: "Timeout"
+      });
       await ctx.edit(await buildTreeDisplayMessage(ctx));
     }, THANKSGIVING_FEAST_MINIGAME_MAX_DURATION);
     disposeActiveTimeouts(ctx);
@@ -61,7 +67,11 @@ export class ThanksgivingFeastMinigame implements Minigame {
       );
 
     ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
-    minigameFinished(ctx as ButtonContext, true, 1, THANKSGIVING_FEAST_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx, {
+      success: true,
+      difficulty: 1,
+      maxDuration: THANKSGIVING_FEAST_MINIGAME_MAX_DURATION
+    });
     transitionToDefaultTreeView(ctx);
   }
 
@@ -74,7 +84,12 @@ export class ThanksgivingFeastMinigame implements Minigame {
       .setDescription("You missed the feast. Better luck next time!");
 
     ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
-    minigameFinished(ctx as ButtonContext, false, 1, THANKSGIVING_FEAST_MINIGAME_MAX_DURATION);
+    await minigameFinished(ctx, {
+      success: false,
+      difficulty: 1,
+      maxDuration: THANKSGIVING_FEAST_MINIGAME_MAX_DURATION,
+      failureReason: "Wrong button"
+    });
     transitionToDefaultTreeView(ctx);
   }
 

--- a/src/models/FailedAttempt.ts
+++ b/src/models/FailedAttempt.ts
@@ -1,0 +1,21 @@
+import { model, Schema } from "mongoose";
+
+interface IFailedAttempt {
+  userId: string;
+  guildId: string;
+  attemptType: string;
+  failureReason: string;
+  timestamp: Date;
+}
+
+const FailedAttemptSchema = new Schema<IFailedAttempt>({
+  userId: { type: String, required: true },
+  guildId: { type: String, required: true },
+  attemptType: { type: String, required: true },
+  failureReason: { type: String, required: true },
+  timestamp: { type: Date, required: true, default: Date.now }
+});
+
+const FailedAttempt = model<IFailedAttempt>("FailedAttempt", FailedAttemptSchema);
+
+export { FailedAttempt, FailedAttemptSchema, IFailedAttempt };

--- a/src/models/FailedAttempt.ts
+++ b/src/models/FailedAttempt.ts
@@ -9,11 +9,11 @@ interface IFailedAttempt {
 }
 
 const FailedAttemptSchema = new Schema<IFailedAttempt>({
-  userId: { type: String, required: true },
-  guildId: { type: String, required: true },
+  userId: { type: String, required: true, index: true },
+  guildId: { type: String, required: true, index: true },
   attemptType: { type: String, required: true },
   failureReason: { type: String, required: true },
-  timestamp: { type: Date, required: true, default: Date.now }
+  timestamp: { type: Date, required: true, default: Date.now, index: true }
 });
 
 const FailedAttempt = model<IFailedAttempt>("FailedAttempt", FailedAttemptSchema);

--- a/src/models/FlaggedUser.ts
+++ b/src/models/FlaggedUser.ts
@@ -1,0 +1,19 @@
+import { model, Schema } from "mongoose";
+
+interface IFlaggedUser {
+  userId: string;
+  guildId: string;
+  reason: string;
+  timestamp: Date;
+}
+
+const FlaggedUserSchema = new Schema<IFlaggedUser>({
+  userId: { type: String, required: true },
+  guildId: { type: String, required: true },
+  reason: { type: String, required: true },
+  timestamp: { type: Date, required: true, default: Date.now }
+});
+
+const FlaggedUser = model<IFlaggedUser>("FlaggedUser", FlaggedUserSchema);
+
+export { FlaggedUser, FlaggedUserSchema, IFlaggedUser };

--- a/src/models/FlaggedUser.ts
+++ b/src/models/FlaggedUser.ts
@@ -8,8 +8,8 @@ interface IFlaggedUser {
 }
 
 const FlaggedUserSchema = new Schema<IFlaggedUser>({
-  userId: { type: String, required: true },
-  guildId: { type: String, required: true },
+  userId: { type: String, required: true, index: true },
+  guildId: { type: String, required: true, index: true },
   reason: { type: String, required: true },
   timestamp: { type: Date, required: true, default: Date.now }
 });

--- a/src/util/anti-bot/antiBotCleanupTimer.ts
+++ b/src/util/anti-bot/antiBotCleanupTimer.ts
@@ -1,0 +1,8 @@
+import { cleanOldFailedAttempts } from "./antiBotHelper";
+
+export function startAntiBotCleanupTimer() {
+  cleanOldFailedAttempts();
+  setInterval(async () => {
+    await cleanOldFailedAttempts();
+  }, 1000 * 60 * 60 * 24);
+}

--- a/src/util/anti-bot/antiBotHelper.ts
+++ b/src/util/anti-bot/antiBotHelper.ts
@@ -1,0 +1,79 @@
+import { FailedAttempt } from "../../models/FailedAttempt";
+import { FlaggedUser } from "../../models/FlaggedUser";
+
+const AUTOCLICKER_THRESHOLD = 15;
+const AUTOCLICKER_TIMEFRAME = 1000 * 60 * 60; // 1 hour
+
+export async function countFailedAttempts(userId: string, guildId: string): Promise<number> {
+  const now = new Date();
+  const startTime = new Date(now.getTime() - AUTOCLICKER_TIMEFRAME);
+
+  const failedAttempts = await FailedAttempt.countDocuments({
+    userId,
+    guildId,
+    timestamp: { $gte: startTime, $lte: now }
+  });
+
+  return failedAttempts;
+}
+
+export async function isUserFlagged(userId: string, guildId: string): Promise<boolean> {
+  const now = new Date();
+  const startTime = new Date(now.getTime() - AUTOCLICKER_TIMEFRAME);
+
+  const flaggedUser = await FlaggedUser.findOne({
+    userId,
+    guildId,
+    timestamp: { $gte: startTime, $lte: now }
+  });
+
+  return !!flaggedUser;
+}
+
+export async function flagPotentialAutoClickers(userId: string, guildId?: string): Promise<void> {
+  if (!guildId) return;
+  const failedAttempts = await countFailedAttempts(userId, guildId);
+
+  if (failedAttempts > AUTOCLICKER_THRESHOLD) {
+    const isFlagged = await isUserFlagged(userId, guildId);
+
+    if (!isFlagged) {
+      console.log(`User ${userId} in guild ${guildId} flagged as potential auto-clicker.`);
+      const flaggedUser = new FlaggedUser({
+        userId,
+        guildId,
+        reason: "Potential auto-clicker",
+        timestamp: new Date()
+      });
+      await flaggedUser.save();
+      // Add your logic to handle flagged users here, such as logging or applying penalties.
+    }
+  }
+}
+
+export async function saveFailedAttempt(
+  userId: string,
+  guildId: string,
+  attemptType: string,
+  failureReason: string
+): Promise<void> {
+  const failedAttempt = new FailedAttempt({
+    userId,
+    guildId,
+    attemptType,
+    failureReason
+  });
+
+  await failedAttempt.save();
+}
+
+export async function cleanOldFailedAttempts(): Promise<void> {
+  const now = new Date();
+  const cutoffTime = new Date(now.getTime() - AUTOCLICKER_TIMEFRAME);
+
+  await FailedAttempt.deleteMany({
+    timestamp: { $lt: cutoffTime }
+  });
+
+  console.log("Old failed attempts cleaned up.");
+}

--- a/src/util/anti-bot/antiBotHelper.ts
+++ b/src/util/anti-bot/antiBotHelper.ts
@@ -5,6 +5,7 @@ import { UnleashHelper } from "../unleash/UnleashHelper";
 
 const AUTOCLICKER_THRESHOLD = 15;
 const AUTOCLICKER_TIMEFRAME = 1000 * 60 * 60; // 1 hour
+const AUTOCLICKER_FLAGGED_TIMEFRAME = 1000 * 60 * 60 * 24; // 24 hours
 const UNLEASH_AUTOCLICKER_FLAGGING = "anti-auto-clicker-logging";
 
 export async function countFailedAttempts(ctx: SlashCommandContext | ButtonContext<unknown>): Promise<number> {
@@ -28,7 +29,7 @@ export async function countFailedAttempts(ctx: SlashCommandContext | ButtonConte
 export async function isUserFlagged(ctx: SlashCommandContext | ButtonContext<unknown>): Promise<boolean> {
   if (UnleashHelper.isEnabled(UNLEASH_AUTOCLICKER_FLAGGING, ctx)) {
     const now = new Date();
-    const startTime = new Date(now.getTime() - AUTOCLICKER_TIMEFRAME);
+    const startTime = new Date(now.getTime() - AUTOCLICKER_FLAGGED_TIMEFRAME);
     const userId = ctx.user.id;
     const guildId = ctx.game?.id;
     const flaggedUser = await FlaggedUser.findOne({
@@ -47,10 +48,8 @@ export async function flagPotentialAutoClickers(ctx: SlashCommandContext | Butto
     const userId = ctx.user.id;
     const guildId = ctx.game?.id;
     const failedAttempts = await countFailedAttempts(ctx);
-
     if (failedAttempts > AUTOCLICKER_THRESHOLD) {
       const isFlagged = await isUserFlagged(ctx);
-
       if (!isFlagged) {
         console.log(`User ${userId} in guild ${guildId} flagged as potential auto-clicker.`);
         const flaggedUser = new FlaggedUser({

--- a/src/util/discord/DiscordApiExtensions.ts
+++ b/src/util/discord/DiscordApiExtensions.ts
@@ -12,7 +12,10 @@ export const GOLDEN_COIN_STASH_SKU_ID = "1304819461366480946";
 export const LUCKY_COIN_BAG_SKU_ID = "1304819131543195738";
 export const TREASURE_CHEST_OF_COINS_SKU_ID = "1304819358442192936";
 
-export function getEntitlements(ctx: SlashCommandContext | ButtonContext, withoutExpired = false): Entitlement[] {
+export function getEntitlements(
+  ctx: SlashCommandContext | ButtonContext | ButtonContext<unknown>,
+  withoutExpired = false
+): Entitlement[] {
   const interaction = ctx.interaction;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const entitlements: Entitlement[] = (interaction as any).entitlements;
@@ -42,7 +45,9 @@ export function hasEntitlementExpired(entitlement: Entitlement): boolean {
   return new Date(entitlement.ends_at) < new Date();
 }
 
-export async function updateEntitlementsToGame(ctx: SlashCommandContext | ButtonContext): Promise<void> {
+export async function updateEntitlementsToGame(
+  ctx: SlashCommandContext | ButtonContext | ButtonContext<unknown>
+): Promise<void> {
   try {
     if (ctx.game == null) return;
 
@@ -100,6 +105,10 @@ export async function fetchEntitlementsFromApi(
   } catch (error: unknown) {
     return [];
   }
+}
+
+export function getRandomButtonStyle(): ButtonStyle {
+  return (Math.floor(Math.random() * 4) + 1) as ButtonStyle;
 }
 
 export async function consumeEntitlement(entitlementId: string): Promise<boolean> {

--- a/src/util/unleash/UnleashHelper.ts
+++ b/src/util/unleash/UnleashHelper.ts
@@ -8,7 +8,9 @@ export const unleash = initialize({
 });
 
 export class UnleashHelper {
-  static getUnleashContext(ctx: SlashCommandContext | ButtonContext | ButtonContext<never>): Context {
+  static getUnleashContext(
+    ctx: SlashCommandContext | ButtonContext | ButtonContext<never> | ButtonContext<unknown>
+  ): Context {
     return {
       userId: ctx.game?.id ?? ctx.user.id,
       properties: {
@@ -21,7 +23,7 @@ export class UnleashHelper {
   }
   static isEnabled(
     name: string,
-    ctx: SlashCommandContext | ButtonContext | ButtonContext<never>,
+    ctx: SlashCommandContext | ButtonContext | ButtonContext<never> | ButtonContext<unknown>,
     fallbackValue = false
   ): boolean {
     return unleash.isEnabled(name, this.getUnleashContext(ctx), fallbackValue);


### PR DESCRIPTION
Fixes #66

Add logging for failed attempts and flag potential auto-clickers.

* **FailedAttempt Model**: Create a new schema for logging failed attempts with fields `userId`, `guildId`, `attemptType`, `failureReason`, and `timestamp`.
* **Tree Command**: Import `FailedAttempt` model. Add a function to log failed watering attempts. Call the logging function when a watering attempt fails due to the tree not being ready.
* **MinigameFactory**: Import `FailedAttempt` model. Add a function to log failed minigame attempts. Call the logging function when a minigame attempt fails due to timeout or wrong button.
* **Index**: Import `FailedAttempt` model. Add a function to check the number of failed attempts for a user within a specified time frame. Call the function to flag users as potential auto-clickers if the number of failed attempts exceeds the threshold.
* **FlaggedUser Model**: Create a new schema for storing flagged users with fields `userId`, `guildId`, `reason`, and `timestamp`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GewoonJaap/grow-a-christmas-tree/pull/97?shareId=87ed1250-d5c0-4567-aba3-8f1f2d7d0bfb).