### PR TITLE
Add wheel of fortune command

### DIFF
--- a/src/commands/DailyReward.ts
+++ b/src/commands/DailyReward.ts
@@ -14,7 +14,7 @@ import { MessageUpsellType } from "../util/types/MessageUpsellType";
 import { FESTIVE_ENTITLEMENT_SKU_ID, PremiumButtonBuilder } from "../util/discord/DiscordApiExtensions";
 import { BanHelper } from "../util/bans/BanHelper";
 import { UnleashHelper, UNLEASH_FEATURES } from "../util/unleash/UnleashHelper";
-import { WheelState } from "../models/WheelState";
+import { WheelStateHelper } from "../util/wheel/WheelStateHelper";
 
 const GRACE_PERIOD_DAYS = 1;
 const PREMIUM_GRACE_PERIOD_DAYS = 3;
@@ -111,20 +111,17 @@ async function buildDailyRewardMessage(ctx: SlashCommandContext | ButtonContext)
   await wallet.save();
 
   // Add tickets when the user claims their daily reward
-  const wheelState = await WheelState.findOne({ userId });
-  if (wheelState) {
-    wheelState.tickets += isPremium ? 2 : 1;
-    await wheelState.save();
-  } else {
-    await WheelState.create({ userId, tickets: isPremium ? 2 : 1, lastSpinDate: new Date(0), theme: "default" });
-  }
+  const claimedTickets = isPremium ? 2 : 1;
+  await WheelStateHelper.addTickets(userId, claimedTickets);
 
   const embed = new EmbedBuilder()
     .setTitle("Daily Reward")
     .setDescription(
-      `<@${ctx.user.id}> You have claimed your daily reward of ${reward} coins.\n\nCurrent Streak: ${
-        wallet.streak
-      } day${wallet.streak === 1 ? "" : "s"}.\n\n${
+      `<@${
+        ctx.user.id
+      }> You have claimed your daily reward of ${reward} coins.\n<:wheeloffortune:1312084380922937397>You also gained ${claimedTickets} ticket${
+        claimedTickets === 1 ? "" : "s"
+      } for the wheel of fortune!\n\nCurrent Streak: ${wallet.streak} day${wallet.streak === 1 ? "" : "s"}.\n\n${
         isPremium
           ? `As a premium user, you receive more coins and have a ${PREMIUM_GRACE_PERIOD_DAYS} day grace period!`
           : `Subscribe to Festive Forest to receive more coins and a ${PREMIUM_GRACE_PERIOD_DAYS} day grace period! Click on the bot avatar to open the [store](https://discord.com/application-directory/1050722873569968128/store).`

--- a/src/commands/RedeemPurschages.ts
+++ b/src/commands/RedeemPurschages.ts
@@ -14,18 +14,23 @@ import {
   consumeEntitlement,
   SMALL_POUCH_OF_COINS_SKU_ID,
   skuIdToCoins,
+  skuIdToLuckyTickets,
   GOLDEN_COIN_STASH_SKU_ID,
   LUCKY_COIN_BAG_SKU_ID,
-  TREASURE_CHEST_OF_COINS_SKU_ID
+  TREASURE_CHEST_OF_COINS_SKU_ID,
+  HOLIDAY_LUCKY_TICKET,
+  LUCKY_TICKET_25,
+  LUCKY_TICKET_50
 } from "../util/discord/DiscordApiExtensions";
 import { WalletHelper } from "../util/wallet/WalletHelper";
 import { PremiumButtons } from "../util/buttons/PremiumButtons";
+import { WheelStateHelper } from "../util/wheel/WheelStateHelper";
 
-const builder = new SlashCommandBuilder("redeemcoins", "Redeem all your coin purchases from the shop");
+const builder = new SlashCommandBuilder("redeempurschages", "Redeem all your purchases from the shop");
 
 builder.setDMEnabled(false);
 
-export class RedeemCoinsCommand implements ISlashCommand {
+export class RedeemPurschagesCommand implements ISlashCommand {
   public builder = builder;
 
   public handler = async (ctx: SlashCommandContext): Promise<void> => {
@@ -53,14 +58,17 @@ async function buildRedeemCoinsMessage(ctx: SlashCommandContext | ButtonContext)
     SMALL_POUCH_OF_COINS_SKU_ID,
     GOLDEN_COIN_STASH_SKU_ID,
     LUCKY_COIN_BAG_SKU_ID,
-    TREASURE_CHEST_OF_COINS_SKU_ID
+    TREASURE_CHEST_OF_COINS_SKU_ID,
+    HOLIDAY_LUCKY_TICKET,
+    LUCKY_TICKET_25,
+    LUCKY_TICKET_50
   ]);
 
   if (entitlements.length === 0) {
     const embed = new EmbedBuilder()
-      .setTitle("Coins Redeemed")
+      .setTitle("Purchases Redeemed")
       .setColor(0xff0000)
-      .setDescription("You have no coins to redeem.")
+      .setDescription("You have no purchases to redeem.")
       .setFooter({ text: `You can purchase coins from the store by clicking on the bot avatar or the button.` });
 
     const message = new MessageBuilder().addEmbed(embed);
@@ -74,11 +82,13 @@ async function buildRedeemCoinsMessage(ctx: SlashCommandContext | ButtonContext)
   }
 
   let totalCoins = 0;
+  let totalLuckyTickets = 0;
 
   for (const entitlement of entitlements) {
     const success = await consumeEntitlement(entitlement.id);
     if (success) {
       totalCoins += skuIdToCoins(entitlement.sku_id);
+      totalLuckyTickets += skuIdToLuckyTickets(entitlement.sku_id);
     }
   }
 
@@ -86,9 +96,13 @@ async function buildRedeemCoinsMessage(ctx: SlashCommandContext | ButtonContext)
     await WalletHelper.addCoins(ctx.user.id, totalCoins);
   }
 
+  if (totalLuckyTickets > 0) {
+    await WheelStateHelper.addTickets(ctx.user.id, totalLuckyTickets);
+  }
+
   const embed = new EmbedBuilder()
-    .setTitle("Coins Redeemed")
-    .setDescription(`You have successfully redeemed ${totalCoins} coins.`);
+    .setTitle("Purchases Redeemed")
+    .setDescription(`You have successfully redeemed ${totalCoins} coins and ${totalLuckyTickets} lucky tickets.`);
 
   const message = new MessageBuilder().addEmbed(embed);
   const actions = new ActionRowBuilder().addComponents(

--- a/src/commands/RedeemPurschages.ts
+++ b/src/commands/RedeemPurschages.ts
@@ -69,7 +69,7 @@ async function buildRedeemCoinsMessage(ctx: SlashCommandContext | ButtonContext)
       .setTitle("Purchases Redeemed")
       .setColor(0xff0000)
       .setDescription("You have no purchases to redeem.")
-      .setFooter({ text: `You can purchase coins from the store by clicking on the bot avatar or the button.` });
+      .setFooter({ text: `You can purchase items from the store by clicking on the bot avatar or the button.` });
 
     const message = new MessageBuilder().addEmbed(embed);
     const actions = new ActionRowBuilder();

--- a/src/commands/Wheel.ts
+++ b/src/commands/Wheel.ts
@@ -1,0 +1,156 @@
+import {
+  ActionRowBuilder,
+  Button,
+  ButtonBuilder,
+  ButtonContext,
+  EmbedBuilder,
+  ISlashCommand,
+  MessageBuilder,
+  SlashCommandBuilder,
+  SlashCommandContext
+} from "interactions.ts";
+import { WheelState } from "../models/WheelState";
+import { WalletHelper } from "../util/wallet/WalletHelper";
+import { getRandomElement } from "../util/helpers/arrayHelper";
+import { PremiumButtonBuilder } from "../util/discord/DiscordApiExtensions";
+
+const REWARD_PROBABILITIES = {
+  tickets: 0.3,
+  coins: 0.5,
+  composterUpgrade: 0.15,
+  other: 0.05
+};
+
+export class Wheel implements ISlashCommand {
+  public builder = new SlashCommandBuilder("wheel", "Spin the wheel of fortune for rewards.");
+
+  public handler = async (ctx: SlashCommandContext): Promise<void> => {
+    const userId = ctx.user.id;
+    const wheelState = await WheelState.findOne({ userId });
+
+    if (!wheelState) {
+      await WheelState.create({ userId, tickets: 1, lastSpinDate: new Date(0), theme: "default" });
+    }
+
+    return await ctx.reply(await buildWheelMessage(ctx));
+  };
+
+  public components = [
+    new Button(
+      "wheel.spin",
+      new ButtonBuilder().setEmoji({ name: "🎡" }).setStyle(1).setLabel("Spin the Wheel"),
+      async (ctx: ButtonContext): Promise<void> => {
+        return await ctx.reply(await handleSpin(ctx));
+      }
+    ),
+    new Button(
+      "wheel.refresh",
+      new ButtonBuilder().setEmoji({ name: "🔄" }).setStyle(2).setLabel("Refresh"),
+      async (ctx: ButtonContext): Promise<void> => {
+        return await ctx.reply(await buildWheelMessage(ctx));
+      }
+    )
+  ];
+}
+
+async function buildWheelMessage(ctx: SlashCommandContext | ButtonContext): Promise<MessageBuilder> {
+  const userId = ctx.user.id;
+  const wheelState = await WheelState.findOne({ userId });
+
+  if (!wheelState) {
+    return new MessageBuilder().addEmbed(
+      new EmbedBuilder()
+        .setTitle("Wheel of Fortune")
+        .setDescription("You need to have at least one ticket to spin the wheel.")
+        .setColor(0xff0000)
+    );
+  }
+
+  const embed = new EmbedBuilder()
+    .setTitle("Wheel of Fortune")
+    .setDescription(
+      `🎡 **Spin the Wheel of Fortune!** 🎡\n\nYou have ${wheelState.tickets} ticket(s) available.\n\nSpin the wheel to win exciting rewards like tickets, coins, and composter upgrades!`
+    )
+    .setImage("https://example.com/wheel-image.jpg");
+
+  const actionRow = new ActionRowBuilder().addComponents(
+    await ctx.manager.components.createInstance("wheel.spin"),
+    await ctx.manager.components.createInstance("wheel.refresh")
+  );
+
+  return new MessageBuilder().addEmbed(embed).addComponents(actionRow);
+}
+
+async function handleSpin(ctx: ButtonContext): Promise<MessageBuilder> {
+  const userId = ctx.user.id;
+  const wheelState = await WheelState.findOne({ userId });
+
+  if (!wheelState || wheelState.tickets <= 0) {
+    return new MessageBuilder().addEmbed(
+      new EmbedBuilder()
+        .setTitle("Wheel of Fortune")
+        .setDescription("You need to have at least one ticket to spin the wheel.")
+        .setColor(0xff0000)
+    );
+  }
+
+  wheelState.tickets--;
+  wheelState.lastSpinDate = new Date();
+
+  const reward = determineReward();
+  await applyReward(ctx, reward);
+
+  await wheelState.save();
+
+  const embed = new EmbedBuilder()
+    .setTitle("Wheel of Fortune")
+    .setDescription(`You spun the wheel and won ${reward}!`)
+    .setColor(0x00ff00);
+
+  const actionRow = new ActionRowBuilder().addComponents(
+    await ctx.manager.components.createInstance("wheel.spin"),
+    await ctx.manager.components.createInstance("wheel.refresh")
+  );
+
+  return new MessageBuilder().addEmbed(embed).addComponents(actionRow);
+}
+
+function determineReward(): string {
+  const random = Math.random();
+  let cumulativeProbability = 0;
+
+  for (const [reward, probability] of Object.entries(REWARD_PROBABILITIES)) {
+    cumulativeProbability += probability;
+    if (random < cumulativeProbability) {
+      return reward;
+    }
+  }
+
+  return "other";
+}
+
+async function applyReward(ctx: ButtonContext, reward: string): Promise<void> {
+  const userId = ctx.user.id;
+
+  switch (reward) {
+    case "tickets":
+      const wheelState = await WheelState.findOne({ userId });
+      if (wheelState) {
+        wheelState.tickets += 1;
+        await wheelState.save();
+      }
+      break;
+    case "coins":
+      await WalletHelper.addCoins(userId, 100);
+      break;
+    case "composterUpgrade":
+      const guild = ctx.game;
+      if (guild) {
+        guild.composter.efficiencyLevel += 1;
+        await guild.save();
+      }
+      break;
+    default:
+      break;
+  }
+}

--- a/src/commands/Wheel.ts
+++ b/src/commands/Wheel.ts
@@ -12,7 +12,14 @@ import {
 import { WalletHelper } from "../util/wallet/WalletHelper";
 import { WheelStateHelper } from "../util/wheel/WheelStateHelper";
 
-const REWARDS = {
+type RewardType = "tickets" | "coins" | "composterUpgrade" | "nothing";
+
+interface Reward {
+  displayName: string;
+  probability: number;
+}
+
+const REWARDS: Record<RewardType, Reward> = {
   tickets: { displayName: "Tickets", probability: 0.3 },
   coins: { displayName: "Coins", probability: 0.5 },
   composterUpgrade: { displayName: "Composter Upgrade", probability: 0.15 },
@@ -118,7 +125,7 @@ async function handleSpin(ctx: ButtonContext): Promise<MessageBuilder> {
   return new MessageBuilder().addEmbed(embed).addComponents(actionRow);
 }
 
-function determineReward(isPremium: boolean): { type: string; amount?: number } {
+function determineReward(isPremium: boolean): { type: RewardType; amount?: number } {
   const random = Math.random();
   let cumulativeProbability = 0;
 
@@ -126,16 +133,16 @@ function determineReward(isPremium: boolean): { type: string; amount?: number } 
     cumulativeProbability += probability;
     if (random < cumulativeProbability) {
       if (reward === "coins") {
-        return { type: reward, amount: Math.floor(Math.random() * (isPremium ? 100 : 50)) }; // Specify the amount of coins
+        return { type: reward as RewardType, amount: Math.floor(Math.random() * (isPremium ? 100 : 50)) }; // Specify the amount of coins
       }
-      return { type: reward };
+      return { type: reward as RewardType };
     }
   }
 
   return { type: "nothing" };
 }
 
-async function applyReward(ctx: ButtonContext, reward: { type: string; amount?: number }): Promise<void> {
+async function applyReward(ctx: ButtonContext, reward: { type: RewardType; amount?: number }): Promise<void> {
   const userId = ctx.user.id;
 
   switch (reward.type) {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -8,7 +8,7 @@ export * from "./Tree";
 export * from "./Recycle";
 export * from "./NotificationSettings";
 export * from "./SendCoins";
-export * from "./RedeemCoins";
+export * from "./RedeemPurschages";
 export * from "./DailyReward";
 export * from "./Composter";
 export * from "./SetTimezone";

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -13,3 +13,4 @@ export * from "./DailyReward";
 export * from "./Composter";
 export * from "./SetTimezone";
 export * from "./ServerInfo";
+export * from "./Wheel";

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,8 @@ import {
   DailyReward,
   Composter,
   SetTimezone,
-  ServerInfo
+  ServerInfo,
+  Wheel
 } from "./commands";
 import { Guild, IGuild } from "./models/Guild";
 import { fetchStats } from "./api/stats";
@@ -130,7 +131,8 @@ if (keys.some((key) => !(key in process.env))) {
       new DailyReward(),
       new Composter(),
       new SetTimezone(),
-      new ServerInfo()
+      new ServerInfo(),
+      new Wheel()
     ],
     false
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,12 +28,12 @@ import {
   Recycle,
   NotificationSettings,
   SendCoinsCommand,
-  RedeemCoinsCommand,
   DailyReward,
   Composter,
   SetTimezone,
   ServerInfo,
-  Wheel
+  Wheel,
+  RedeemPurschagesCommand
 } from "./commands";
 import { Guild, IGuild } from "./models/Guild";
 import { fetchStats } from "./api/stats";
@@ -127,7 +127,7 @@ if (keys.some((key) => !(key in process.env))) {
       new Feedback(),
       new NotificationSettings(),
       new SendCoinsCommand(),
-      new RedeemCoinsCommand(),
+      new RedeemPurschagesCommand(),
       new DailyReward(),
       new Composter(),
       new SetTimezone(),

--- a/src/models/WheelState.ts
+++ b/src/models/WheelState.ts
@@ -1,0 +1,19 @@
+import { model, Schema } from "mongoose";
+
+interface IWheelState {
+  userId: string;
+  tickets: number;
+  lastSpinDate: Date;
+  theme: string;
+}
+
+const WheelStateSchema = new Schema<IWheelState>({
+  userId: { type: String, required: true, unique: true, index: true },
+  tickets: { type: Number, required: true, default: 0 },
+  lastSpinDate: { type: Date, required: true, default: new Date("1999-01-01T00:00:00Z") },
+  theme: { type: String, required: true, default: "default" }
+});
+
+const WheelState = model<IWheelState>("WheelState", WheelStateSchema);
+
+export { WheelState, WheelStateSchema, IWheelState };

--- a/src/models/WheelState.ts
+++ b/src/models/WheelState.ts
@@ -4,14 +4,12 @@ interface IWheelState {
   userId: string;
   tickets: number;
   lastSpinDate: Date;
-  theme: string;
 }
 
 const WheelStateSchema = new Schema<IWheelState>({
   userId: { type: String, required: true, unique: true, index: true },
   tickets: { type: Number, required: true, default: 0 },
-  lastSpinDate: { type: Date, required: true, default: new Date("1999-01-01T00:00:00Z") },
-  theme: { type: String, required: true, default: "default" }
+  lastSpinDate: { type: Date, required: true, default: new Date("1999-01-01T00:00:00Z") }
 });
 
 const WheelState = model<IWheelState>("WheelState", WheelStateSchema);

--- a/src/util/buttons/PremiumButtons.ts
+++ b/src/util/buttons/PremiumButtons.ts
@@ -2,22 +2,40 @@ import {
   FESTIVE_ENTITLEMENT_SKU_ID,
   PremiumButtonBuilder,
   SMALL_POUCH_OF_COINS_SKU_ID,
-  SUPER_THIRSTY_ENTITLEMENT_SKU_ID
+  SUPER_THIRSTY_ENTITLEMENT_SKU_ID,
+  HOLIDAY_LUCKY_TICKET,
+  LUCKY_TICKET_25,
+  LUCKY_TICKET_50
 } from "../discord/DiscordApiExtensions";
 
 export class PremiumButtons {
   /**
-   * A button that allows users to purschage the Festive Forest
+   * A button that allows users to purchase the Festive Forest
    */
   static FestiveForestButton = new PremiumButtonBuilder().setSkuId(FESTIVE_ENTITLEMENT_SKU_ID);
 
   /**
-   * A button that allows users to purschage a small pouch of coins
+   * A button that allows users to purchase a small pouch of coins
    */
   static SmallPouchOfCoinsButton = new PremiumButtonBuilder().setSkuId(SMALL_POUCH_OF_COINS_SKU_ID);
 
   /**
-   * A button that allows users to purschage the Super Thirsty entitlement
+   * A button that allows users to purchase the Super Thirsty entitlement
    */
   static SuperThirstyButton = new PremiumButtonBuilder().setSkuId(SUPER_THIRSTY_ENTITLEMENT_SKU_ID);
+
+  /**
+   * A button that allows users to purchase the Holiday Lucky Ticket
+   */
+  static HolidayLuckyTicketButton = new PremiumButtonBuilder().setSkuId(HOLIDAY_LUCKY_TICKET);
+
+  /**
+   * A button that allows users to purchase 25 Lucky Tickets
+   */
+  static LuckyTicket25Button = new PremiumButtonBuilder().setSkuId(LUCKY_TICKET_25);
+
+  /**
+   * A button that allows users to purchase 50 Lucky Tickets
+   */
+  static LuckyTicket50Button = new PremiumButtonBuilder().setSkuId(LUCKY_TICKET_50);
 }

--- a/src/util/discord/DiscordApiExtensions.ts
+++ b/src/util/discord/DiscordApiExtensions.ts
@@ -11,6 +11,9 @@ export const SMALL_POUCH_OF_COINS_SKU_ID = "1302385817846550611";
 export const GOLDEN_COIN_STASH_SKU_ID = "1304819461366480946";
 export const LUCKY_COIN_BAG_SKU_ID = "1304819131543195738";
 export const TREASURE_CHEST_OF_COINS_SKU_ID = "1304819358442192936";
+export const HOLIDAY_LUCKY_TICKET = "1312106259608244287";
+export const LUCKY_TICKET_25 = "1312108891076690011";
+export const LUCKY_TICKET_50 = "1312108952905056316";
 
 export function getEntitlements(
   ctx: SlashCommandContext | ButtonContext | ButtonContext<unknown>,
@@ -139,6 +142,19 @@ export function skuIdToCoins(skuId: string): number {
       return 1500;
     case TREASURE_CHEST_OF_COINS_SKU_ID:
       return 3000;
+    default:
+      return 0;
+  }
+}
+
+export function skuIdToLuckyTickets(skuId: string): number {
+  switch (skuId) {
+    case HOLIDAY_LUCKY_TICKET:
+      return 10;
+    case LUCKY_TICKET_25:
+      return 25;
+    case LUCKY_TICKET_50:
+      return 50;
     default:
       return 0;
   }

--- a/src/util/wheel/WheelStateHelper.ts
+++ b/src/util/wheel/WheelStateHelper.ts
@@ -1,0 +1,30 @@
+import { WheelState } from "../../models/WheelState";
+
+export class WheelStateHelper {
+  static async getWheelState(userId: string): Promise<InstanceType<typeof WheelState>> {
+    const wheelState = await WheelState.findOne({ userId: userId });
+    if (!wheelState) {
+      return await WheelState.create(WheelStateHelper.getDefaultWheelState(userId));
+    }
+    return wheelState;
+  }
+
+  static getDefaultWheelState(userId: string): InstanceType<typeof WheelState> {
+    return { userId: userId, tickets: 0, lastSpinDate: new Date("1999-01-01T00:00:00Z"), theme: "default" };
+  }
+
+  static async addTickets(userId: string, amount: number) {
+    if (amount < 0) {
+      amount *= -1;
+    }
+    const wheelState = await WheelStateHelper.getWheelState(userId);
+    wheelState.tickets += amount;
+    await wheelState.save();
+  }
+
+  static async updateLastSpinDate(userId: string, lastSpinDate: Date) {
+    const wheelState = await WheelStateHelper.getWheelState(userId);
+    wheelState.lastSpinDate = lastSpinDate;
+    await wheelState.save();
+  }
+}

--- a/src/util/wheel/WheelStateHelper.ts
+++ b/src/util/wheel/WheelStateHelper.ts
@@ -10,7 +10,7 @@ export class WheelStateHelper {
   }
 
   static getDefaultWheelState(userId: string): IWheelState {
-    return { userId: userId, tickets: 0, lastSpinDate: new Date("1999-01-01T00:00:00Z"), theme: "default" };
+    return { userId: userId, tickets: 0, lastSpinDate: new Date("1999-01-01T00:00:00Z") };
   }
 
   static async addTickets(userId: string, amount: number) {

--- a/src/util/wheel/WheelStateHelper.ts
+++ b/src/util/wheel/WheelStateHelper.ts
@@ -1,4 +1,4 @@
-import { WheelState } from "../../models/WheelState";
+import { IWheelState, WheelState } from "../../models/WheelState";
 
 export class WheelStateHelper {
   static async getWheelState(userId: string): Promise<InstanceType<typeof WheelState>> {
@@ -9,7 +9,7 @@ export class WheelStateHelper {
     return wheelState;
   }
 
-  static getDefaultWheelState(userId: string): InstanceType<typeof WheelState> {
+  static getDefaultWheelState(userId: string): IWheelState {
     return { userId: userId, tickets: 0, lastSpinDate: new Date("1999-01-01T00:00:00Z"), theme: "default" };
   }
 
@@ -19,12 +19,23 @@ export class WheelStateHelper {
     }
     const wheelState = await WheelStateHelper.getWheelState(userId);
     wheelState.tickets += amount;
+    wheelState.tickets = Math.max(wheelState.tickets, 0);
+    wheelState.tickets = Math.min(wheelState.tickets, 100);
     await wheelState.save();
   }
 
-  static async updateLastSpinDate(userId: string, lastSpinDate: Date) {
+  static async spinWheel(userId: string): Promise<boolean> {
     const wheelState = await WheelStateHelper.getWheelState(userId);
-    wheelState.lastSpinDate = lastSpinDate;
+
+    if (wheelState.tickets <= 0) {
+      return false;
+    }
+
+    wheelState.tickets--;
+    wheelState.lastSpinDate = new Date();
+
     await wheelState.save();
+
+    return true;
   }
 }


### PR DESCRIPTION
Fixes #107

Add the wheel of fortune command to allow users to spin the wheel and receive rewards.

* **New Command Implementation**
  - Add `Wheel.ts` in `src/commands` to handle the wheel of fortune functionality.
  - Implement logic to check user's ticket count and last spin date.
  - Provide rewards like tickets, coins, and composter upgrades.
  - Include additional spins for users in premium guilds.
  - Use `Button` components to handle spinning action and refreshing wheel status.

* **Database Model**
  - Create `WheelState.ts` in `src/models` to store `userId`, `tickets`, `lastSpinDate`, and `theme`.

* **Command Registration**
  - Register the new `Wheel` command in `src/index.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GewoonJaap/grow-a-christmas-tree/pull/108?shareId=1e46007d-af8e-4b77-abf1-ce83da8f51bd).