### PR TITLE
Add advent calendar command

### DIFF
--- a/src/commands/About.ts
+++ b/src/commands/About.ts
@@ -27,6 +27,7 @@ export class About implements ISlashCommand {
           **Profile and Rewards**
           👤 **/profile** - View your profile and the amount of coins you have.
           📖 **/dailyreward** - Claim your daily supply of free coins.
+          🎁 **/adventcalendar** - Open your daily advent calendar present.
           🪙 **/redeemcoins** - Redeem any outstanding purchases from the shop.
           💸 **/sendcoins** - Transfer coins to another player.
 

--- a/src/commands/AdventCalendar.ts
+++ b/src/commands/AdventCalendar.ts
@@ -1,4 +1,14 @@
-import { EmbedBuilder, ISlashCommand, MessageBuilder, SlashCommandBuilder, SlashCommandContext } from "interactions.ts";
+import {
+  EmbedBuilder,
+  ISlashCommand,
+  MessageBuilder,
+  SlashCommandBuilder,
+  SlashCommandContext,
+  Button,
+  ButtonBuilder,
+  ButtonContext,
+  ActionRowBuilder
+} from "interactions.ts";
 import { BanHelper } from "../util/bans/BanHelper";
 import { UnleashHelper, UNLEASH_FEATURES } from "../util/unleash/UnleashHelper";
 import { AdventCalendarHelper } from "../util/adventCalendar/AdventCalendarHelper";
@@ -6,72 +16,118 @@ import { AdventCalendarHelper } from "../util/adventCalendar/AdventCalendarHelpe
 export class AdventCalendar implements ISlashCommand {
   public builder = new SlashCommandBuilder("adventcalendar", "Open your daily advent calendar present!");
 
-  public handler = async (ctx: SlashCommandContext): Promise<void> => {
-    if (UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) && (await BanHelper.isUserBanned(ctx.user.id))) {
-      return await ctx.reply(BanHelper.getBanEmbed(ctx.user.username));
-    }
-
-    if (!ctx.game || ctx.isDM) {
-      return await ctx.reply("This command can only be used in a server with a tree planted.");
-    }
-
-    const userId = ctx.user.id;
-    const currentDate = new Date();
-    const currentYear = currentDate.getFullYear();
-    const startOfAdvent = new Date(currentYear, 11, 1); // December 1st
-    const endOfAdvent = new Date(currentYear, 11, 25, 23, 59, 59); // December 25th
-
-    if (currentDate < startOfAdvent || currentDate > endOfAdvent) {
-      const nextChristmas = currentDate > endOfAdvent ? new Date(currentYear + 1, 11, 1) : new Date(currentYear, 11, 1); // December 1st of next year if after December 25th, otherwise this year
-
-      const embed = new EmbedBuilder()
-        .setTitle("Advent Calendar")
-        .setDescription(
-          `🎄 The advent calendar is only available from December 1st until Christmas. Please come back on December 1st. 🎅\n\nNext advent calendar starts in <t:${Math.floor(
-            nextChristmas.getTime() / 1000
-          )}:R>.`
-        )
-        .setColor(0xff0000)
-        .setImage(
-          "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/advent-calendar/advent-calendar-1.jpg"
-        );
-
-      return await ctx.reply(new MessageBuilder().addEmbed(embed));
-    }
-
-    const hasOpenedPresent = await AdventCalendarHelper.hasClaimedToday(userId);
-
-    if (hasOpenedPresent) {
-      const nextOpenDate = AdventCalendarHelper.getNextClaimDay(
-        (await AdventCalendarHelper.getLastClaimDay(userId)) ?? new Date()
-      );
-      const embed = new EmbedBuilder()
-        .setTitle("Advent Calendar")
-        .setDescription(
-          `🎁 You have already opened your present for today. You can open your next present <t:${Math.floor(
-            nextOpenDate.getTime() / 1000
-          )}:R>.`
-        )
-        .setColor(0xff0000);
-
-      return await ctx.reply(new MessageBuilder().addEmbed(embed));
-    }
-
-    const present = await AdventCalendarHelper.addClaimedDay(ctx);
-
-    if (!present) {
-      return await ctx.reply("An error occurred while opening your present. Please try again later.");
-    }
-
-    const embed = new EmbedBuilder()
-      .setTitle("Advent Calendar")
-      .setDescription(
-        `🎉 You have opened your advent calendar present and received ${present.amount} ${present.type}! Come back tomorrow for another present.`
-      )
-      .setColor(0x00ff00);
-
-    return await ctx.reply(new MessageBuilder().addEmbed(embed));
+  public handler = async (ctx: SlashCommandContext | ButtonContext): Promise<void> => {
+    return await ctx.reply(await buildAdventCalendarMessage(ctx));
   };
 
-  public components = [];
+  public components = [
+    new Button(
+      "adventcalendar.refresh",
+      new ButtonBuilder().setEmoji({ name: "🔄" }).setStyle(2).setLabel("Refresh"),
+      async (ctx: ButtonContext): Promise<void> => {
+        return await ctx.reply(await buildAdventCalendarMessage(ctx));
+      }
+    )
+  ];
+}
+
+async function buildAdventCalendarMessage(ctx: SlashCommandContext | ButtonContext): Promise<MessageBuilder> {
+  if (UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) && (await BanHelper.isUserBanned(ctx.user.id))) {
+    return BanHelper.getBanEmbed(ctx.user.username);
+  }
+
+  if (!ctx.game || ctx.isDM) {
+    return new MessageBuilder().setContent("This command can only be used in a server with a tree planted.");
+  }
+
+  const userId = ctx.user.id;
+  const currentDate = new Date();
+  const currentYear = currentDate.getFullYear();
+  const startOfAdvent = new Date(currentYear, 11, 1); // December 1st
+  const endOfAdvent = new Date(currentYear, 11, 25, 23, 59, 59); // December 25th
+
+  if (currentDate < startOfAdvent || currentDate > endOfAdvent) {
+    const nextChristmas = currentDate > endOfAdvent ? new Date(currentYear + 1, 11, 1) : new Date(currentYear, 11, 1); // December 1st of next year if after December 25th, otherwise this year
+    return await buildAdventCalendarUnavailableMessage(ctx, nextChristmas);
+  }
+
+  const hasOpenedPresent = await AdventCalendarHelper.hasClaimedToday(userId);
+
+  if (hasOpenedPresent) {
+    const nextOpenDate = AdventCalendarHelper.getNextClaimDay(
+      (await AdventCalendarHelper.getLastClaimDay(userId)) ?? new Date()
+    );
+    return await buildAlreadyOpenedMessage(ctx, nextOpenDate);
+  }
+
+  const present = await AdventCalendarHelper.addClaimedDay(ctx);
+
+  if (!present) {
+    return new MessageBuilder().setContent("An error occurred while opening your present. Please try again later.");
+  }
+
+  return buildPresentOpenedMessage(ctx, present);
+}
+
+async function buildAdventCalendarUnavailableMessage(
+  ctx: SlashCommandContext | ButtonContext,
+  nextChristmas: Date
+): Promise<MessageBuilder> {
+  const embed = new EmbedBuilder()
+    .setTitle("Advent Calendar")
+    .setDescription(
+      `🎄 The advent calendar is only available from December 1st until Christmas. Please come back on December 1st. 🎅\n\nNext advent calendar starts in <t:${Math.floor(
+        nextChristmas.getTime() / 1000
+      )}:R>.`
+    )
+    .setColor(0xff0000)
+    .setImage("https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/advent-calendar/advent-calendar-1.jpg");
+
+  const actionRow = new ActionRowBuilder().addComponents(
+    await ctx.manager.components.createInstance("adventcalendar.refresh")
+  );
+
+  return new MessageBuilder().addEmbed(embed).addComponents(actionRow);
+}
+
+async function buildAlreadyOpenedMessage(
+  ctx: SlashCommandContext | ButtonContext,
+  nextOpenDate: Date
+): Promise<MessageBuilder> {
+  const embed = new EmbedBuilder()
+    .setTitle("Advent Calendar")
+    .setDescription(
+      `🎁 <@${
+        ctx.user.id
+      }>, You have already opened your present for today. You can open your next present <t:${Math.floor(
+        nextOpenDate.getTime() / 1000
+      )}:R>.`
+    )
+    .setColor(0xff0000)
+    .setImage("https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/advent-calendar/advent-calendar-1.jpg");
+
+  const actionRow = new ActionRowBuilder().addComponents(
+    await ctx.manager.components.createInstance("adventcalendar.refresh")
+  );
+
+  return new MessageBuilder().addEmbed(embed).addComponents(actionRow);
+}
+
+async function buildPresentOpenedMessage(
+  ctx: SlashCommandContext | ButtonContext,
+  present: { type: string; amount?: number }
+): Promise<MessageBuilder> {
+  const embed = new EmbedBuilder()
+    .setTitle("Advent Calendar")
+    .setDescription(
+      `🎉 <@${ctx.user.id}>, You have opened your advent calendar present and received ${present.amount} ${present.type}! Come back tomorrow for another present.`
+    )
+    .setColor(0x00ff00)
+    .setImage("https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/advent-calendar/advent-calendar-1.jpg");
+
+  const actionRow = new ActionRowBuilder().addComponents(
+    await ctx.manager.components.createInstance("adventcalendar.refresh")
+  );
+
+  return new MessageBuilder().addEmbed(embed).addComponents(actionRow);
 }

--- a/src/commands/AdventCalendar.ts
+++ b/src/commands/AdventCalendar.ts
@@ -14,7 +14,10 @@ import { UnleashHelper, UNLEASH_FEATURES } from "../util/unleash/UnleashHelper";
 import { AdventCalendarHelper } from "../util/adventCalendar/AdventCalendarHelper";
 
 export class AdventCalendar implements ISlashCommand {
-  public builder = new SlashCommandBuilder("adventcalendar", "Open your daily advent calendar present!");
+  public builder = new SlashCommandBuilder(
+    "adventcalendar",
+    "🎅 Unwrap your daily gift from Santa's Advent Calendar! 🎁"
+  );
 
   public handler = async (ctx: SlashCommandContext | ButtonContext): Promise<void> => {
     return await ctx.reply(await buildAdventCalendarMessage(ctx));
@@ -74,7 +77,7 @@ async function buildAdventCalendarUnavailableMessage(
   nextChristmas: Date
 ): Promise<MessageBuilder> {
   const embed = new EmbedBuilder()
-    .setTitle("Advent Calendar")
+    .setTitle("🎁 Santa's Advent Calendar 🎄")
     .setDescription(
       `🎄 The advent calendar is only available from December 1st until Christmas. Please come back on December 1st. 🎅\n\nNext advent calendar starts in <t:${Math.floor(
         nextChristmas.getTime() / 1000
@@ -95,11 +98,11 @@ async function buildAlreadyOpenedMessage(
   nextOpenDate: Date
 ): Promise<MessageBuilder> {
   const embed = new EmbedBuilder()
-    .setTitle("Advent Calendar")
+    .setTitle("🎁 Santa's Advent Calendar 🎄")
     .setDescription(
       `🎁 <@${
         ctx.user.id
-      }>, You have already opened your present for today. You can open your next present <t:${Math.floor(
+      }>, You've already unwrapped today's gift! Come back tomorrow to open the next one. 🎁 <t:${Math.floor(
         nextOpenDate.getTime() / 1000
       )}:R>.`
     )
@@ -118,9 +121,9 @@ async function buildPresentOpenedMessage(
   present: { type: string; amount?: number }
 ): Promise<MessageBuilder> {
   const embed = new EmbedBuilder()
-    .setTitle("Advent Calendar")
+    .setTitle("🎁 Santa's Advent Calendar 🎄")
     .setDescription(
-      `🎉 <@${ctx.user.id}>, You have opened your advent calendar present and received ${present.amount} ${present.type}! Come back tomorrow for another present.`
+      `🎉 <@${ctx.user.id}>, You've unwrapped your advent calendar gift and received ${present.amount} ${present.type}! Check back tomorrow for more festive surprises. 🎄`
     )
     .setColor(0x00ff00)
     .setImage("https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/advent-calendar/advent-calendar-1.jpg");

--- a/src/commands/AdventCalendar.ts
+++ b/src/commands/AdventCalendar.ts
@@ -1,0 +1,79 @@
+import {
+  EmbedBuilder,
+  ISlashCommand,
+  MessageBuilder,
+  SlashCommandBuilder,
+  SlashCommandContext
+} from "interactions.ts";
+import { WalletHelper } from "../util/wallet/WalletHelper";
+import { AdventCalendarHelper } from "../util/adventCalendar/AdventCalendarHelper";
+import { BanHelper } from "../util/bans/BanHelper";
+import { UnleashHelper, UNLEASH_FEATURES } from "../util/unleash/UnleashHelper";
+import { getLocaleFromTimezone } from "../util/timezones";
+import { AdventCalendar } from "../models/AdventCalendar";
+import { Achievement } from "../models/Achievement";
+
+export class AdventCalendar implements ISlashCommand {
+  public builder = new SlashCommandBuilder("adventcalendar", "Open your daily advent calendar present!");
+
+  public handler = async (ctx: SlashCommandContext): Promise<void> => {
+    if (UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) && (await BanHelper.isUserBanned(ctx.user.id))) {
+      return await ctx.reply(BanHelper.getBanEmbed(ctx.user.username));
+    }
+
+    const userId = ctx.user.id;
+    const guildId = ctx.interaction.guild_id;
+    const currentDate = new Date();
+    const userTimeZone = await AdventCalendarHelper.getUserTimeZone(userId, guildId);
+    const userLocale = getLocaleFromTimezone(userTimeZone);
+
+    const hasOpenedPresent = await AdventCalendarHelper.hasOpenedPresent(userId, currentDate, userTimeZone);
+
+    if (hasOpenedPresent) {
+      const nextOpenDate = AdventCalendarHelper.getNextOpenDate(currentDate, userTimeZone);
+      const embed = new EmbedBuilder()
+        .setTitle("Advent Calendar")
+        .setDescription(
+          `🎁 You have already opened your present for today. You can open your next present <t:${Math.floor(
+            nextOpenDate.getTime() / 1000
+          )}:R>.`
+        )
+        .setColor(0xff0000);
+
+      return await ctx.reply(new MessageBuilder().addEmbed(embed));
+    }
+
+    const present = AdventCalendarHelper.getDailyPresent();
+    await AdventCalendarHelper.saveUserPresent(userId, currentDate, present);
+
+    const wallet = await WalletHelper.getWallet(userId);
+    wallet.coins += present.coins;
+    await wallet.save();
+
+    const embed = new EmbedBuilder()
+      .setTitle("Advent Calendar")
+      .setDescription(
+        `🎉 You have opened your advent calendar present and received ${present.coins} coins! Come back tomorrow for another present.`
+      )
+      .setColor(0x00ff00);
+
+    // Check for achievements
+    const achievements = await Achievement.find({ userId });
+    const streakAchievement = achievements.find((achievement) => achievement.achievementName === "Daily Streak");
+
+    if (!streakAchievement) {
+      const newAchievement = new Achievement({
+        userId,
+        achievementName: "Daily Streak",
+        description: "Opened a present for the first time",
+        dateEarned: new Date(),
+        badgeUrl: "https://example.com/badge.png"
+      });
+      await newAchievement.save();
+    }
+
+    return await ctx.reply(new MessageBuilder().addEmbed(embed));
+  };
+
+  public components = [];
+}

--- a/src/commands/Profile.ts
+++ b/src/commands/Profile.ts
@@ -15,6 +15,7 @@ import { WalletHelper } from "../util/wallet/WalletHelper";
 import { BanHelper } from "../util/bans/BanHelper";
 import { CHEATER_CLOWN_EMOJI } from "../util/const";
 import { UnleashHelper, UNLEASH_FEATURES } from "../util/unleash/UnleashHelper";
+import { Achievement } from "../models/Achievement";
 
 type State = {
   id: string;
@@ -76,6 +77,15 @@ async function buildProfileMessage(ctx: SlashCommandContext | ButtonContext<Stat
   const contributorRank =
     ctx.game.contributors.sort((a, b) => b.count - a.count).findIndex((contributor) => contributor.userId === id) + 1;
 
+  const achievements = await Achievement.find({ userId: id });
+
+  const achievementsDescription = achievements
+    .map(
+      (achievement) =>
+        `🏅 **${achievement.achievementName}**\n${achievement.description}\nEarned on: ${achievement.dateEarned.toDateString()}\n`
+    )
+    .join("\n");
+
   return new MessageBuilder()
     .addEmbed(
       new EmbedBuilder()
@@ -89,7 +99,7 @@ async function buildProfileMessage(ctx: SlashCommandContext | ButtonContext<Stat
               : "not yet watered the christmas tree."
           }\n\n🪙Current Coin Balance: ${wallet ? wallet.coins : 0} coins.\n\n🔥Current Streak: ${
             wallet ? wallet.streak : 0
-          } day${(wallet?.streak ?? 0) === 1 ? "" : "s"}.`
+          } day${(wallet?.streak ?? 0) === 1 ? "" : "s"}.\n\n${achievementsDescription}`
         )
     )
     .addComponents(

--- a/src/commands/Profile.ts
+++ b/src/commands/Profile.ts
@@ -82,7 +82,9 @@ async function buildProfileMessage(ctx: SlashCommandContext | ButtonContext<Stat
   const achievementsDescription = achievements
     .map(
       (achievement) =>
-        `🏅 **${achievement.achievementName}**\n${achievement.description}\nEarned on: ${achievement.dateEarned.toDateString()}\n`
+        `🏅 **${achievement.achievementName}**\n${
+          achievement.description
+        }\nEarned on: ${achievement.dateEarned.toDateString()}\n`
     )
     .join("\n");
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -14,3 +14,4 @@ export * from "./Composter";
 export * from "./SetTimezone";
 export * from "./ServerInfo";
 export * from "./Wheel";
+export * from "./AdventCalendar";

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,8 @@ import {
   SetTimezone,
   ServerInfo,
   Wheel,
-  RedeemPurschagesCommand
+  RedeemPurschagesCommand,
+  AdventCalendar
 } from "./commands";
 import { Guild, IGuild } from "./models/Guild";
 import { fetchStats } from "./api/stats";
@@ -132,7 +133,8 @@ if (keys.some((key) => !(key in process.env))) {
       new Composter(),
       new SetTimezone(),
       new ServerInfo(),
-      new Wheel()
+      new Wheel(),
+      new AdventCalendar()
     ],
     false
   );

--- a/src/models/Achievement.ts
+++ b/src/models/Achievement.ts
@@ -1,0 +1,21 @@
+import { model, Schema } from "mongoose";
+
+interface IAchievement {
+  userId: string;
+  achievementName: string;
+  description: string;
+  dateEarned: Date;
+  badgeUrl: string;
+}
+
+const AchievementSchema = new Schema<IAchievement>({
+  userId: { type: String, required: true, index: true },
+  achievementName: { type: String, required: true },
+  description: { type: String, required: true },
+  dateEarned: { type: Date, required: true, default: Date.now },
+  badgeUrl: { type: String, required: true }
+});
+
+const Achievement = model<IAchievement>("Achievement", AchievementSchema);
+
+export { Achievement, AchievementSchema, IAchievement };

--- a/src/models/Achievement.ts
+++ b/src/models/Achievement.ts
@@ -5,7 +5,7 @@ interface IAchievement {
   achievementName: string;
   description: string;
   dateEarned: Date;
-  badgeUrl: string;
+  emoji: string;
 }
 
 const AchievementSchema = new Schema<IAchievement>({
@@ -13,7 +13,7 @@ const AchievementSchema = new Schema<IAchievement>({
   achievementName: { type: String, required: true },
   description: { type: String, required: true },
   dateEarned: { type: Date, required: true, default: Date.now },
-  badgeUrl: { type: String, required: true }
+  emoji: { type: String, required: true }
 });
 
 const Achievement = model<IAchievement>("Achievement", AchievementSchema);

--- a/src/models/AdventCalendar.ts
+++ b/src/models/AdventCalendar.ts
@@ -1,0 +1,21 @@
+import { model, Schema } from "mongoose";
+
+interface IAdventCalendar {
+  userId: string;
+  claimDate: Date;
+  presentType: string;
+  daysClaimed: number;
+  year: number;
+}
+
+const AdventCalendarSchema = new Schema<IAdventCalendar>({
+  userId: { type: String, required: true, index: true },
+  claimDate: { type: Date, required: true, default: Date.now },
+  presentType: { type: String, required: true },
+  daysClaimed: { type: Number, required: true, default: 0 },
+  year: { type: Number, required: true, default: new Date().getFullYear() }
+});
+
+const AdventCalendar = model<IAdventCalendar>("AdventCalendar", AdventCalendarSchema);
+
+export { AdventCalendar, AdventCalendarSchema, IAdventCalendar };

--- a/src/models/AdventCalendar.ts
+++ b/src/models/AdventCalendar.ts
@@ -2,17 +2,13 @@ import { model, Schema } from "mongoose";
 
 interface IAdventCalendar {
   userId: string;
-  claimDate: Date;
-  presentType: string;
-  daysClaimed: number;
+  claimDates: Date[];
   year: number;
 }
 
 const AdventCalendarSchema = new Schema<IAdventCalendar>({
-  userId: { type: String, required: true, index: true },
-  claimDate: { type: Date, required: true, default: Date.now },
-  presentType: { type: String, required: true },
-  daysClaimed: { type: Number, required: true, default: 0 },
+  userId: { type: String, required: true, index: true, unique: true },
+  claimDates: { type: [Date], required: true, default: [] },
   year: { type: Number, required: true, default: new Date().getFullYear() }
 });
 

--- a/src/util/achievement/AchievementHelper.ts
+++ b/src/util/achievement/AchievementHelper.ts
@@ -1,0 +1,80 @@
+import { IAchievement, Achievement } from "../../models/Achievement";
+
+interface AchievementConfig {
+  name: string;
+  description: string;
+  emoji: string;
+}
+
+const ACHIEVEMENTS: Record<string, AchievementConfig> = {
+  "Daily Streak": {
+    name: "Daily Streak",
+    description: "Opened a present for the first time",
+    emoji: "🎁"
+  },
+  "Coin Collector": {
+    name: "Coin Collector",
+    description: "Collected 1000 coins",
+    emoji: "💰"
+  },
+  "Ticket Master": {
+    name: "Ticket Master",
+    description: "Collected 50 tickets",
+    emoji: "🎟️"
+  },
+  "Advent Calendar Completion": {
+    name: "Advent Calendar Completion",
+    description: "Opened all presents in the advent calendar",
+    emoji: "🎄"
+  },
+  "Wheel of Fortune Winner": {
+    name: "Wheel of Fortune Winner",
+    description: "Won a prize on the wheel of fortune",
+    emoji: "🎡"
+  },
+  "Tree Waterer": {
+    name: "Tree Waterer",
+    description: "Watered the tree 1 time",
+    emoji: "🌲"
+  },
+  "Advent Calendar 2024 Participation": {
+    name: "Advent Calendar 2024 Participation",
+    description: "Participated in the 2024 advent calendar",
+    emoji: "🎅"
+  }
+};
+
+export type AchievementName = keyof typeof ACHIEVEMENTS;
+
+export class AchievementHelper {
+  static async grantAchievement(userId: string, achievementName: AchievementName): Promise<void> {
+    const achievementConfig = ACHIEVEMENTS[achievementName];
+    if (!achievementConfig) {
+      throw new Error(`Achievement ${achievementName} not found`);
+    }
+
+    const existingAchievement = await Achievement.findOne({ userId, achievementName });
+    if (existingAchievement) {
+      return; // User already has this achievement
+    }
+
+    const newAchievement = new Achievement({
+      userId,
+      achievementName: achievementConfig.name,
+      description: achievementConfig.description,
+      dateEarned: new Date(),
+      emoji: achievementConfig.emoji
+    });
+
+    await newAchievement.save();
+  }
+
+  static async hasAchievement(userId: string, achievementName: AchievementName): Promise<boolean> {
+    const achievement = await Achievement.findOne({ userId, achievementName });
+    return !!achievement;
+  }
+
+  static async getAchievements(userId: string): Promise<IAchievement[]> {
+    return await Achievement.find({ userId });
+  }
+}

--- a/src/util/adventCalendar/AdventCalendarHelper.ts
+++ b/src/util/adventCalendar/AdventCalendarHelper.ts
@@ -1,0 +1,161 @@
+import { ButtonContext, SlashCommandContext } from "interactions.ts";
+import { IAdventCalendar, AdventCalendar } from "../../models/AdventCalendar";
+import { WalletHelper } from "../wallet/WalletHelper";
+import { WheelStateHelper } from "../wheel/WheelStateHelper";
+import { AchievementHelper } from "../achievement/AchievementHelper";
+
+const SECONDS_IN_A_DAY = 60 * 60 * 24;
+const MILLISECONDS_IN_A_SECOND = 1000;
+
+type PresentType = "coins" | "tickets" | "treeSize";
+
+export interface Present {
+  displayName: string;
+  probability: number;
+}
+
+const PRESENTS: Record<PresentType, Present> = {
+  coins: { displayName: "Coins", probability: 0.5 },
+  tickets: { displayName: "Tickets", probability: 0.3 },
+  treeSize: { displayName: "Tree Size Increase", probability: 0.2 }
+};
+
+export class AdventCalendarHelper {
+  static async getAdventCalendar(
+    userId: string,
+    year: number = new Date().getFullYear()
+  ): Promise<InstanceType<typeof AdventCalendar>> {
+    const adventCalendar = await AdventCalendar.findOne({ userId: userId, year: year });
+    if (!adventCalendar) {
+      return await AdventCalendar.create(AdventCalendarHelper.getDefaultAdventCalendar(userId, year));
+    }
+    return adventCalendar;
+  }
+
+  static async getAdventCalendars(
+    userIds: string[],
+    year: number = new Date().getFullYear()
+  ): Promise<Map<string, InstanceType<typeof AdventCalendar>>> {
+    const adventCalendars = await AdventCalendar.find({ userId: { $in: userIds }, year: year });
+    const adventCalendarMap = new Map<string, InstanceType<typeof AdventCalendar>>();
+
+    // Add existing advent calendars to the map
+    adventCalendars.forEach((adventCalendar) => {
+      adventCalendarMap.set(adventCalendar.userId, adventCalendar);
+    });
+
+    // Create missing advent calendars and add them to the map
+    const missingUserIds = userIds.filter((userId) => !adventCalendarMap.has(userId));
+    const newAdventCalendars = await AdventCalendar.insertMany(
+      missingUserIds.map((userId) => AdventCalendarHelper.getDefaultAdventCalendar(userId, year))
+    );
+
+    newAdventCalendars.forEach((adventCalendar) => {
+      adventCalendarMap.set(adventCalendar.userId, adventCalendar);
+    });
+
+    return adventCalendarMap;
+  }
+
+  static getDefaultAdventCalendar(userId: string, year: number): IAdventCalendar {
+    return { userId: userId, claimDates: [], year: year };
+  }
+
+  static async addClaimedDay(
+    ctx: SlashCommandContext | ButtonContext | ButtonContext<unknown>,
+    year: number = new Date().getFullYear()
+  ): Promise<{ type: PresentType; amount?: number } | null> {
+    const adventCalendar = await AdventCalendarHelper.getAdventCalendar(ctx.user.id, year);
+    const today = new Date();
+    const alreadyClaimed = adventCalendar.claimDates.some((date) => date.toDateString() === today.toDateString());
+
+    if (!alreadyClaimed) {
+      adventCalendar.claimDates.push(today);
+      await adventCalendar.save();
+      const present = AdventCalendarHelper.determinePresent(ctx);
+      await AdventCalendarHelper.applyPresent(ctx, present);
+
+      AchievementHelper.grantAchievement(ctx.user.id, "Advent Calendar 2024 Participation");
+
+      if (adventCalendar.claimDates.length === 25) {
+        AchievementHelper.grantAchievement(ctx.user.id, "Advent Calendar Completion");
+      }
+
+      return present;
+    }
+    return null;
+  }
+
+  static async getClaimedDays(userId: string, year: number = new Date().getFullYear()): Promise<Date[]> {
+    const adventCalendar = await AdventCalendarHelper.getAdventCalendar(userId, year);
+    return adventCalendar.claimDates;
+  }
+
+  static async hasClaimedToday(userId: string, year: number = new Date().getFullYear()): Promise<boolean> {
+    const adventCalendar = await AdventCalendarHelper.getAdventCalendar(userId, year);
+    const today = new Date();
+    return adventCalendar.claimDates.some((date) => date.toDateString() === today.toDateString());
+  }
+
+  static getNextClaimDay(claimDate: Date): Date {
+    const nextDay = new Date(claimDate.getTime() + SECONDS_IN_A_DAY * MILLISECONDS_IN_A_SECOND);
+    console.log(nextDay, nextDay.getTime());
+    return new Date(nextDay.getFullYear(), nextDay.getMonth(), nextDay.getDate(), 0, 0, 0);
+  }
+
+  static async getLastClaimDay(userId: string, year: number = new Date().getFullYear()): Promise<Date | null> {
+    const adventCalendar = await AdventCalendarHelper.getAdventCalendar(userId, year);
+    return adventCalendar.claimDates[adventCalendar.claimDates.length - 1] || null;
+  }
+
+  static determinePresent(ctx: SlashCommandContext | ButtonContext | ButtonContext<unknown>): {
+    type: PresentType;
+    amount?: number;
+  } {
+    const random = Math.random();
+    let cumulativeProbability = 0;
+    const isPremium = ctx.game?.hasAiAccess ?? false;
+
+    for (const [present, { probability }] of Object.entries(PRESENTS) as [PresentType, Present][]) {
+      cumulativeProbability += probability;
+      if (random < cumulativeProbability) {
+        if (present === "coins") {
+          return { type: present, amount: Math.floor(Math.random() * (isPremium ? 100 : 50)) + 1 }; // Random amount of coins between 1 and 100
+        } else if (present === "tickets") {
+          return { type: present, amount: Math.floor(Math.random() * (isPremium ? 10 : 5)) + 1 }; // Random amount of tickets between 1 and 5
+        } else if (present === "treeSize") {
+          return { type: present, amount: Math.floor(Math.random() * (isPremium ? 10 : 5)) + 1 }; // Random 1 or 2 ft
+        }
+        return { type: present };
+      }
+    }
+
+    return { type: "coins", amount: 10 };
+  }
+
+  static async applyPresent(
+    ctx: SlashCommandContext | ButtonContext | ButtonContext<unknown>,
+    present: { type: PresentType; amount?: number }
+  ): Promise<void> {
+    switch (present.type) {
+      case "coins":
+        if (present.amount) {
+          await WalletHelper.addCoins(ctx.user.id, present.amount);
+        }
+        break;
+      case "tickets":
+        if (present.amount) {
+          await WheelStateHelper.addTickets(ctx.user.id, present.amount);
+        }
+        break;
+      case "treeSize":
+        if (present.amount && ctx.game) {
+          ctx.game.size += present.amount;
+          await ctx.game.save();
+        }
+        break;
+      default:
+        break;
+    }
+  }
+}


### PR DESCRIPTION
Fixes #109

Add advent calendar command to allow users to open daily presents.

* **Advent Calendar Command**
  - Add `src/commands/AdventCalendar.ts` to define the advent calendar command.
  - Implement daily present opening logic and check if the user has already opened a present for the day.
  - Provide hardcoded presents and store the user's daily present status in the database.
  - Handle different time zones and prevent users from opening multiple presents in a single day.
  - Check for achievements and save new achievements if applicable.

* **Models**
  - Add `src/models/Achievement.ts` to define the structure of an achievement and map it to a MongoDB collection.
  - Add `src/models/AdventCalendar.ts` to define the structure of an advent calendar claim and map it to a MongoDB collection.

* **Profile Command**
  - Update `src/commands/Profile.ts` to display user achievements and badges.
  - Retrieve user achievements and badges from the database and add the information to the profile embed.

* **Command Index**
  - Add an export for the new `AdventCalendar` command in `src/commands/index.ts`.

* **About Command**
  - Update `src/commands/About.ts` to include the advent calendar command in the profile and rewards section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GewoonJaap/grow-a-christmas-tree/pull/110?shareId=c82af2b3-bfd7-40ca-a03a-0d3dc1db7cfe).