### PR TITLE
Add random tree size reward to lucky spinner

### DIFF
--- a/src/commands/Wheel.ts
+++ b/src/commands/Wheel.ts
@@ -170,7 +170,7 @@ function determineReward(isPremium: boolean): { type: RewardType; amount?: numbe
       } else if (reward === "composterQualityUpgrade") {
         return { type: reward, amount: 1 }; // Always 1 level upgrade
       } else if (reward === "treeSize") {
-        return { type: reward, amount: Math.floor(Math.random() * 2) + 1 }; // Random 1 or 2 ft
+        return { type: reward, amount: Math.floor(Math.random() * (isPremium ? 25 : 10)) + 1 }; // Random 1 to 10 ft for free users, 1 to 25 ft for premium users
       }
       return { type: reward };
     }


### PR DESCRIPTION
Fixes #111

Update the `determineReward` function to generate random tree sizes based on user type.

* Modify the `determineReward` function to generate random tree sizes from 1 to 10 ft for free users and 1 to 25 ft for premium users.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GewoonJaap/grow-a-christmas-tree/pull/112?shareId=40710af1-dfea-4693-bf6b-0555feacbd32).