### PR TITLE
Add refresh button to minigames

### DIFF
--- a/src/commands/DailyReward.ts
+++ b/src/commands/DailyReward.ts
@@ -142,7 +142,6 @@ async function buildDailyRewardMessage(ctx: SlashCommandContext | ButtonContext)
 
 function getNextClaimDayEpoch(claimDate: Date): number {
   const nextDay = new Date(claimDate.getTime() + SECONDS_IN_A_DAY * MILLISECONDS_IN_A_SECOND);
-  console.log(nextDay, nextDay.getTime());
   return Math.floor(
     new Date(nextDay.getFullYear(), nextDay.getMonth(), nextDay.getDate(), 0, 0, 0).getTime() / MILLISECONDS_IN_A_SECOND
   );

--- a/src/commands/Profile.ts
+++ b/src/commands/Profile.ts
@@ -102,7 +102,6 @@ async function buildProfileMessage(ctx: SlashCommandContext | ButtonContext<Stat
     ctx.game.contributors.sort((a, b) => b.count - a.count).findIndex((contributor) => contributor.userId === id) + 1;
 
   const achievements = await AchievementHelper.getAchievements(id);
-  console.log(achievements);
 
   const achievementsPerPage = 5;
   const start = (page - 1) * achievementsPerPage;
@@ -116,8 +115,6 @@ async function buildProfileMessage(ctx: SlashCommandContext | ButtonContext<Stat
         }\nEarned on: ${achievement.dateEarned.toDateString()}\n`
     )
     .join("\n");
-
-  console.log(achievementsDescription);
 
   const actionRow = new ActionRowBuilder().addComponents(
     await ctx.manager.components.createInstance("profile.refresh", { id, nick, page })

--- a/src/commands/Tree.ts
+++ b/src/commands/Tree.ts
@@ -37,6 +37,7 @@ export class Tree implements ISlashCommand {
   public builder = builder;
 
   public handler = async (ctx: SlashCommandContext): Promise<void> => {
+    disposeActiveTimeouts(ctx);
     if (ctx.isDM) return await ctx.reply("This command can only be used in a server.");
     if (ctx.game === null || !ctx.game) return await ctx.reply("Use /plant to plant a tree for your server first.");
 
@@ -52,6 +53,7 @@ export class Tree implements ISlashCommand {
       "tree.grow",
       new ButtonBuilder().setEmoji({ name: "💧" }).setStyle(1),
       async (ctx: ButtonContext): Promise<void> => {
+        disposeActiveTimeouts(ctx);
         await handleTreeGrow(ctx);
       }
     ),
@@ -59,6 +61,7 @@ export class Tree implements ISlashCommand {
       "tree.refresh",
       new ButtonBuilder().setEmoji({ name: "🔄" }).setStyle(2),
       async (ctx: ButtonContext): Promise<void> => {
+        disposeActiveTimeouts(ctx);
         if (
           UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) &&
           (await BanHelper.isUserBanned(ctx.user.id))

--- a/src/minigames/CarolingChoirMinigame.ts
+++ b/src/minigames/CarolingChoirMinigame.ts
@@ -52,8 +52,7 @@ export class CarolingChoirMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.carolingchoir.note", { currentStage }),
       await ctx.manager.components.createInstance("minigame.carolingchoir.wrongnote-1", { currentStage }),
       await ctx.manager.components.createInstance("minigame.carolingchoir.wrongnote-2", { currentStage }),
-      await ctx.manager.components.createInstance("minigame.carolingchoir.wrongnote-3", { currentStage }),
-      await ctx.manager.components.createInstance("tree.refresh")
+      await ctx.manager.components.createInstance("minigame.carolingchoir.wrongnote-3", { currentStage })
     ];
 
     shuffleArray(buttons);
@@ -83,11 +82,15 @@ export class CarolingChoirMinigame implements Minigame {
     ctx.game.size++;
     await ctx.game.save();
 
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription("You led the carolers perfectly! Your tree has grown 1ft!");
 
-    await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    await ctx.reply(
+      new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons))
+    );
 
     transitionToDefaultTreeView(ctx as ButtonContext);
 
@@ -110,11 +113,16 @@ export class CarolingChoirMinigame implements Minigame {
     disposeActiveTimeouts(ctx);
 
     if (!ctx.game) throw new Error("Game data missing.");
+
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription("You hit a wrong note. Better luck next time!");
 
-    await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    await ctx.reply(
+      new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons))
+    );
 
     transitionToDefaultTreeView(ctx as ButtonContext);
 

--- a/src/minigames/CarolingChoirMinigame.ts
+++ b/src/minigames/CarolingChoirMinigame.ts
@@ -52,7 +52,8 @@ export class CarolingChoirMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.carolingchoir.note", { currentStage }),
       await ctx.manager.components.createInstance("minigame.carolingchoir.wrongnote-1", { currentStage }),
       await ctx.manager.components.createInstance("minigame.carolingchoir.wrongnote-2", { currentStage }),
-      await ctx.manager.components.createInstance("minigame.carolingchoir.wrongnote-3", { currentStage })
+      await ctx.manager.components.createInstance("minigame.carolingchoir.wrongnote-3", { currentStage }),
+      await ctx.manager.components.createInstance("tree.refresh")
     ];
 
     shuffleArray(buttons);

--- a/src/minigames/GiftUnwrappingMinigame.ts
+++ b/src/minigames/GiftUnwrappingMinigame.ts
@@ -28,7 +28,8 @@ export class GiftUnwrappingMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.giftunwrapping.gift"),
       await ctx.manager.components.createInstance("minigame.giftunwrapping.emptybox-1"),
       await ctx.manager.components.createInstance("minigame.giftunwrapping.emptybox-2"),
-      await ctx.manager.components.createInstance("minigame.giftunwrapping.emptybox-3")
+      await ctx.manager.components.createInstance("minigame.giftunwrapping.emptybox-3"),
+      await ctx.manager.components.createInstance("tree.refresh")
     ];
 
     shuffleArray(buttons);

--- a/src/minigames/GiftUnwrappingMinigame.ts
+++ b/src/minigames/GiftUnwrappingMinigame.ts
@@ -28,8 +28,7 @@ export class GiftUnwrappingMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.giftunwrapping.gift"),
       await ctx.manager.components.createInstance("minigame.giftunwrapping.emptybox-1"),
       await ctx.manager.components.createInstance("minigame.giftunwrapping.emptybox-2"),
-      await ctx.manager.components.createInstance("minigame.giftunwrapping.emptybox-3"),
-      await ctx.manager.components.createInstance("tree.refresh")
+      await ctx.manager.components.createInstance("minigame.giftunwrapping.emptybox-3")
     ];
 
     shuffleArray(buttons);
@@ -74,13 +73,15 @@ export class GiftUnwrappingMinigame implements Minigame {
 
     await ctx.game.save();
 
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription(message)
       .setImage(
         "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/gift-unwrapping/gift-unwrapping-1.png"
       );
-    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    ctx.reply(new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons)));
 
     transitionToDefaultTreeView(ctx);
 
@@ -92,10 +93,12 @@ export class GiftUnwrappingMinigame implements Minigame {
 
     if (!ctx.game) throw new Error("Game data missing.");
 
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription("You unwrapped an empty box. Better luck next time!");
-    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    ctx.reply(new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons)));
 
     transitionToDefaultTreeView(ctx);
 

--- a/src/minigames/GrinchHeistMinigame.ts
+++ b/src/minigames/GrinchHeistMinigame.ts
@@ -65,7 +65,8 @@ export class GrinchHeistMinigame implements Minigame {
       await ctx.manager.components.createInstance(GRINCH_BUTTON_NAMES[0], { isPenalty }),
       await ctx.manager.components.createInstance(GRINCH_BUTTON_NAMES[1], { isPenalty }),
       await ctx.manager.components.createInstance(GRINCH_BUTTON_NAMES[2], { isPenalty }),
-      await ctx.manager.components.createInstance(GRINCH_BUTTON_NAMES[3], { isPenalty })
+      await ctx.manager.components.createInstance(GRINCH_BUTTON_NAMES[3], { isPenalty }),
+      await ctx.manager.components.createInstance("tree.refresh")
     ];
 
     shuffleArray(buttons);

--- a/src/minigames/GrinchHeistMinigame.ts
+++ b/src/minigames/GrinchHeistMinigame.ts
@@ -65,8 +65,7 @@ export class GrinchHeistMinigame implements Minigame {
       await ctx.manager.components.createInstance(GRINCH_BUTTON_NAMES[0], { isPenalty }),
       await ctx.manager.components.createInstance(GRINCH_BUTTON_NAMES[1], { isPenalty }),
       await ctx.manager.components.createInstance(GRINCH_BUTTON_NAMES[2], { isPenalty }),
-      await ctx.manager.components.createInstance(GRINCH_BUTTON_NAMES[3], { isPenalty }),
-      await ctx.manager.components.createInstance("tree.refresh")
+      await ctx.manager.components.createInstance(GRINCH_BUTTON_NAMES[3], { isPenalty })
     ];
 
     shuffleArray(buttons);
@@ -98,6 +97,8 @@ export class GrinchHeistMinigame implements Minigame {
     ctx.game.size = toFixed(Math.max(0, ctx.game.size - randomLoss), 2);
     await ctx.game.save();
 
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription(`The Grinch stole part of your tree! You lost ${randomLoss}ft.`)
@@ -112,7 +113,9 @@ export class GrinchHeistMinigame implements Minigame {
         maxDuration: GRINCH_HEIST_MINIGAME_MAX_DURATION,
         failureReason: "Timeout"
       });
-      await ctx.edit(new MessageBuilder().addEmbed(embed).setComponents([]));
+      await ctx.edit(
+        new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons))
+      );
     } else {
       await minigameFinished(ctx, {
         success: false,
@@ -120,7 +123,9 @@ export class GrinchHeistMinigame implements Minigame {
         maxDuration: GRINCH_HEIST_MINIGAME_MAX_DURATION,
         failureReason: "Wrong button"
       });
-      await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+      await ctx.reply(
+        new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons))
+      );
     }
 
     transitionToDefaultTreeView(ctx);
@@ -140,6 +145,8 @@ export class GrinchHeistMinigame implements Minigame {
           await ctx.game.save();
         }
 
+        const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
         const embed = new EmbedBuilder()
           .setTitle(ctx.game.name)
           .setDescription(`You saved the tree!${ctx.state?.isPenalty ? "" : " Your tree grew 1ft taller!"}`)
@@ -147,7 +154,9 @@ export class GrinchHeistMinigame implements Minigame {
             "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/grinch-heist/grinch-tree-saved-1.jpg"
           );
 
-        await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+        await ctx.reply(
+          new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons))
+        );
 
         transitionToDefaultTreeView(ctx);
 

--- a/src/minigames/HolidayCookieCountdownMinigame.ts
+++ b/src/minigames/HolidayCookieCountdownMinigame.ts
@@ -50,7 +50,8 @@ export class HolidayCookieCountdownMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.holidaycookiecountdown.cookie", { currentStage }),
       await ctx.manager.components.createInstance("minigame.holidaycookiecountdown.emptyplate-1", { currentStage }),
       await ctx.manager.components.createInstance("minigame.holidaycookiecountdown.emptyplate-2", { currentStage }),
-      await ctx.manager.components.createInstance("minigame.holidaycookiecountdown.emptyplate-3", { currentStage })
+      await ctx.manager.components.createInstance("minigame.holidaycookiecountdown.emptyplate-3", { currentStage }),
+      await ctx.manager.components.createInstance("tree.refresh")
     ];
 
     shuffleArray(buttons);
@@ -149,6 +150,21 @@ export class HolidayCookieCountdownMinigame implements Minigame {
       "minigame.holidaycookiecountdown.emptyplate-3",
       new ButtonBuilder().setEmoji({ name: "🥠" }).setStyle(getRandomButtonStyle()),
       HolidayCookieCountdownMinigame.handleEmptyPlateButton
+    ),
+    new Button(
+      "tree.refresh",
+      new ButtonBuilder().setEmoji({ name: "🔄" }).setStyle(2),
+      async (ctx: ButtonContext): Promise<void> => {
+        if (
+          UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) &&
+          (await BanHelper.isUserBanned(ctx.user.id))
+        ) {
+          await ctx.reply(BanHelper.getBanEmbed(ctx.user.username));
+          transitionToDefaultTreeView(ctx);
+          return;
+        }
+        return await ctx.reply(await buildTreeDisplayMessage(ctx));
+      }
     )
   ];
 }

--- a/src/minigames/HolidayCookieCountdownMinigame.ts
+++ b/src/minigames/HolidayCookieCountdownMinigame.ts
@@ -50,8 +50,7 @@ export class HolidayCookieCountdownMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.holidaycookiecountdown.cookie", { currentStage }),
       await ctx.manager.components.createInstance("minigame.holidaycookiecountdown.emptyplate-1", { currentStage }),
       await ctx.manager.components.createInstance("minigame.holidaycookiecountdown.emptyplate-2", { currentStage }),
-      await ctx.manager.components.createInstance("minigame.holidaycookiecountdown.emptyplate-3", { currentStage }),
-      await ctx.manager.components.createInstance("tree.refresh")
+      await ctx.manager.components.createInstance("minigame.holidaycookiecountdown.emptyplate-3", { currentStage })
     ];
 
     shuffleArray(buttons);
@@ -75,11 +74,15 @@ export class HolidayCookieCountdownMinigame implements Minigame {
     ctx.game.size++;
     await ctx.game.save();
 
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription("You collected all the cookies! Your tree has grown 1ft!");
 
-    await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    await ctx.reply(
+      new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons))
+    );
 
     await minigameFinished(ctx, {
       success: true,
@@ -105,6 +108,9 @@ export class HolidayCookieCountdownMinigame implements Minigame {
     disposeActiveTimeouts(ctx);
 
     if (!ctx.game) throw new Error("Game data missing.");
+
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription("You missed the cookie. Better luck next time!");
@@ -118,7 +124,9 @@ export class HolidayCookieCountdownMinigame implements Minigame {
         failureReason: "Timeout"
       });
     } else {
-      await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+      await ctx.reply(
+        new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons))
+      );
       await minigameFinished(ctx, {
         success: false,
         difficulty: 1,
@@ -150,21 +158,6 @@ export class HolidayCookieCountdownMinigame implements Minigame {
       "minigame.holidaycookiecountdown.emptyplate-3",
       new ButtonBuilder().setEmoji({ name: "🥠" }).setStyle(getRandomButtonStyle()),
       HolidayCookieCountdownMinigame.handleEmptyPlateButton
-    ),
-    new Button(
-      "tree.refresh",
-      new ButtonBuilder().setEmoji({ name: "🔄" }).setStyle(2),
-      async (ctx: ButtonContext): Promise<void> => {
-        if (
-          UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) &&
-          (await BanHelper.isUserBanned(ctx.user.id))
-        ) {
-          await ctx.reply(BanHelper.getBanEmbed(ctx.user.username));
-          transitionToDefaultTreeView(ctx);
-          return;
-        }
-        return await ctx.reply(await buildTreeDisplayMessage(ctx));
-      }
     )
   ];
 }

--- a/src/minigames/HotCocoaMinigame.ts
+++ b/src/minigames/HotCocoaMinigame.ts
@@ -29,8 +29,7 @@ export class HotCocoaMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.hotcocoa.hotcocoa"),
       await ctx.manager.components.createInstance("minigame.hotcocoa.spilledcocoa-1"),
       await ctx.manager.components.createInstance("minigame.hotcocoa.spilledcocoa-2"),
-      await ctx.manager.components.createInstance("minigame.hotcocoa.spilledcocoa-3"),
-      await ctx.manager.components.createInstance("tree.refresh")
+      await ctx.manager.components.createInstance("minigame.hotcocoa.spilledcocoa-3")
     ];
 
     shuffleArray(buttons);
@@ -61,11 +60,13 @@ export class HotCocoaMinigame implements Minigame {
 
     if (!ctx.game) throw new Error("Game data missing.");
 
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription(`You spilled the cocoa! Better luck next time!`);
 
-    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    ctx.reply(new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons)));
 
     await minigameFinished(ctx, {
       success: false,
@@ -88,12 +89,14 @@ export class HotCocoaMinigame implements Minigame {
         ctx.game.size++;
         await ctx.game.save();
 
+        const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
         const embed = new EmbedBuilder()
           .setTitle(ctx.game.name)
           .setImage("https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/hot-cocoa/hot-cocoa-1.jpg")
           .setDescription(`This hot cocoa is delicious! Your tree has grown 1ft!`);
 
-        ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+        ctx.reply(new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons)));
         await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: HOT_COCOA_MINIGAME_MAX_DURATION });
 
         transitionToDefaultTreeView(ctx);
@@ -113,21 +116,6 @@ export class HotCocoaMinigame implements Minigame {
       "minigame.hotcocoa.spilledcocoa-3",
       new ButtonBuilder().setEmoji({ name: "🥤" }).setStyle(getRandomButtonStyle()),
       HotCocoaMinigame.handleSpilledCocoaButton
-    ),
-    new Button(
-      "tree.refresh",
-      new ButtonBuilder().setEmoji({ name: "🔄" }).setStyle(2),
-      async (ctx: ButtonContext): Promise<void> => {
-        if (
-          UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) &&
-          (await BanHelper.isUserBanned(ctx.user.id))
-        ) {
-          await ctx.reply(BanHelper.getBanEmbed(ctx.user.username));
-          transitionToDefaultTreeView(ctx);
-          return;
-        }
-        return await ctx.reply(await buildTreeDisplayMessage(ctx));
-      }
     )
   ];
 }

--- a/src/minigames/HotCocoaMinigame.ts
+++ b/src/minigames/HotCocoaMinigame.ts
@@ -29,7 +29,8 @@ export class HotCocoaMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.hotcocoa.hotcocoa"),
       await ctx.manager.components.createInstance("minigame.hotcocoa.spilledcocoa-1"),
       await ctx.manager.components.createInstance("minigame.hotcocoa.spilledcocoa-2"),
-      await ctx.manager.components.createInstance("minigame.hotcocoa.spilledcocoa-3")
+      await ctx.manager.components.createInstance("minigame.hotcocoa.spilledcocoa-3"),
+      await ctx.manager.components.createInstance("tree.refresh")
     ];
 
     shuffleArray(buttons);
@@ -112,6 +113,21 @@ export class HotCocoaMinigame implements Minigame {
       "minigame.hotcocoa.spilledcocoa-3",
       new ButtonBuilder().setEmoji({ name: "🥤" }).setStyle(getRandomButtonStyle()),
       HotCocoaMinigame.handleSpilledCocoaButton
+    ),
+    new Button(
+      "tree.refresh",
+      new ButtonBuilder().setEmoji({ name: "🔄" }).setStyle(2),
+      async (ctx: ButtonContext): Promise<void> => {
+        if (
+          UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) &&
+          (await BanHelper.isUserBanned(ctx.user.id))
+        ) {
+          await ctx.reply(BanHelper.getBanEmbed(ctx.user.username));
+          transitionToDefaultTreeView(ctx);
+          return;
+        }
+        return await ctx.reply(await buildTreeDisplayMessage(ctx));
+      }
     )
   ];
 }

--- a/src/minigames/MinigameFactory.ts
+++ b/src/minigames/MinigameFactory.ts
@@ -43,7 +43,8 @@ export const minigameButtons = [
   ...HeartCollectionMinigame.buttons,
   ...PumpkinHuntMinigame.buttons,
   ...StPatricksDayTreasureHuntMinigame.buttons,
-  ...ThanksgivingFeastMinigame.buttons
+  ...ThanksgivingFeastMinigame.buttons,
+  await ctx.manager.components.createInstance("tree.refresh")
 ];
 
 const minigames: Minigame[] = [

--- a/src/minigames/MinigameFactory.ts
+++ b/src/minigames/MinigameFactory.ts
@@ -20,7 +20,7 @@ import { getRandomElement } from "../util/helpers/arrayHelper";
 import { WalletHelper } from "../util/wallet/WalletHelper";
 import { UNLEASH_FEATURES, UnleashHelper } from "../util/unleash/UnleashHelper";
 import { saveFailedAttempt } from "../util/anti-bot/failedAttemptsHelper";
-import { transitionToDefaultTreeView } from "../commands";
+import { buildTreeDisplayMessage, disposeActiveTimeouts, transitionToDefaultTreeView } from "../commands";
 
 export interface MinigameEndedType {
   success: boolean;
@@ -48,7 +48,10 @@ export const minigameButtons = [
   new Button(
     "minigame.refresh",
     new ButtonBuilder().setEmoji({ name: "🔄" }).setLabel("Refresh").setStyle(2),
-    async (ctx) => transitionToDefaultTreeView(ctx, 0)
+    async (ctx) => {
+      disposeActiveTimeouts(ctx);
+      return ctx.reply(await buildTreeDisplayMessage(ctx));
+    }
   )
 ];
 

--- a/src/minigames/MinigameFactory.ts
+++ b/src/minigames/MinigameFactory.ts
@@ -1,4 +1,4 @@
-import { ButtonContext } from "interactions.ts";
+import { Button, ButtonBuilder, ButtonContext } from "interactions.ts";
 import { SantaPresentMinigame } from "./SantaPresentMinigame";
 import { Minigame } from "../util/types/minigame/MinigameType";
 import { HotCocoaMinigame } from "./HotCocoaMinigame";
@@ -20,6 +20,7 @@ import { getRandomElement } from "../util/helpers/arrayHelper";
 import { WalletHelper } from "../util/wallet/WalletHelper";
 import { UNLEASH_FEATURES, UnleashHelper } from "../util/unleash/UnleashHelper";
 import { saveFailedAttempt } from "../util/anti-bot/failedAttemptsHelper";
+import { transitionToDefaultTreeView } from "../commands";
 
 export interface MinigameEndedType {
   success: boolean;
@@ -44,7 +45,11 @@ export const minigameButtons = [
   ...PumpkinHuntMinigame.buttons,
   ...StPatricksDayTreasureHuntMinigame.buttons,
   ...ThanksgivingFeastMinigame.buttons,
-  await ctx.manager.components.createInstance("tree.refresh")
+  new Button(
+    "minigame.refresh",
+    new ButtonBuilder().setEmoji({ name: "🔄" }).setLabel("Refresh").setStyle(2),
+    async (ctx) => transitionToDefaultTreeView(ctx, 0)
+  )
 ];
 
 const minigames: Minigame[] = [

--- a/src/minigames/SantaPresentMinigame.ts
+++ b/src/minigames/SantaPresentMinigame.ts
@@ -26,7 +26,8 @@ export class SantaPresentMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.santapresent.present"),
       await ctx.manager.components.createInstance("minigame.santapresent.witch-1"),
       await ctx.manager.components.createInstance("minigame.santapresent.witch-2"),
-      await ctx.manager.components.createInstance("minigame.santapresent.witch-3")
+      await ctx.manager.components.createInstance("minigame.santapresent.witch-3"),
+      await ctx.manager.components.createInstance("tree.refresh")
     ];
 
     shuffleArray(buttons);
@@ -111,6 +112,21 @@ export class SantaPresentMinigame implements Minigame {
       "minigame.santapresent.witch-3",
       new ButtonBuilder().setEmoji({ name: "🥶" }).setStyle(getRandomButtonStyle()),
       SantaPresentMinigame.handleWitchButton
+    ),
+    new Button(
+      "tree.refresh",
+      new ButtonBuilder().setEmoji({ name: "🔄" }).setStyle(2),
+      async (ctx: ButtonContext): Promise<void> => {
+        if (
+          UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) &&
+          (await BanHelper.isUserBanned(ctx.user.id))
+        ) {
+          await ctx.reply(BanHelper.getBanEmbed(ctx.user.username));
+          transitionToDefaultTreeView(ctx);
+          return;
+        }
+        return await ctx.reply(await buildTreeDisplayMessage(ctx));
+      }
     )
   ];
 }

--- a/src/minigames/SantaPresentMinigame.ts
+++ b/src/minigames/SantaPresentMinigame.ts
@@ -26,8 +26,7 @@ export class SantaPresentMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.santapresent.present"),
       await ctx.manager.components.createInstance("minigame.santapresent.witch-1"),
       await ctx.manager.components.createInstance("minigame.santapresent.witch-2"),
-      await ctx.manager.components.createInstance("minigame.santapresent.witch-3"),
-      await ctx.manager.components.createInstance("tree.refresh")
+      await ctx.manager.components.createInstance("minigame.santapresent.witch-3")
     ];
 
     shuffleArray(buttons);
@@ -59,6 +58,8 @@ export class SantaPresentMinigame implements Minigame {
     ctx.game.size++;
     await ctx.game.save();
 
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription(`Enjoy your present! There was some magic inside which made your tree grow 1ft!`)
@@ -66,7 +67,7 @@ export class SantaPresentMinigame implements Minigame {
         "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/santa-present/santa-present-minigame.jpg"
       );
 
-    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    ctx.reply(new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons)));
 
     await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: SANTA_MINIGAME_MAX_DURATION });
 
@@ -78,9 +79,11 @@ export class SantaPresentMinigame implements Minigame {
 
     if (!ctx.game) throw new Error("Game data missing.");
 
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder().setTitle(ctx.game.name).setDescription(`Whoops! The witch stole your present!`);
 
-    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    ctx.reply(new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons)));
 
     await minigameFinished(ctx, {
       success: false,
@@ -112,21 +115,6 @@ export class SantaPresentMinigame implements Minigame {
       "minigame.santapresent.witch-3",
       new ButtonBuilder().setEmoji({ name: "🥶" }).setStyle(getRandomButtonStyle()),
       SantaPresentMinigame.handleWitchButton
-    ),
-    new Button(
-      "tree.refresh",
-      new ButtonBuilder().setEmoji({ name: "🔄" }).setStyle(2),
-      async (ctx: ButtonContext): Promise<void> => {
-        if (
-          UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) &&
-          (await BanHelper.isUserBanned(ctx.user.id))
-        ) {
-          await ctx.reply(BanHelper.getBanEmbed(ctx.user.username));
-          transitionToDefaultTreeView(ctx);
-          return;
-        }
-        return await ctx.reply(await buildTreeDisplayMessage(ctx));
-      }
     )
   ];
 }

--- a/src/minigames/SnowballFightMinigame.ts
+++ b/src/minigames/SnowballFightMinigame.ts
@@ -29,8 +29,7 @@ export class SnowballFightMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.snowballfight.snowball"),
       await ctx.manager.components.createInstance("minigame.snowballfight.miss-1"),
       await ctx.manager.components.createInstance("minigame.snowballfight.miss-2"),
-      await ctx.manager.components.createInstance("minigame.snowballfight.miss-3"),
-      await ctx.manager.components.createInstance("tree.refresh")
+      await ctx.manager.components.createInstance("minigame.snowballfight.miss-3")
     ];
 
     shuffleArray(buttons);
@@ -66,8 +65,12 @@ export class SnowballFightMinigame implements Minigame {
 
     await ctx.game.save();
 
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder().setTitle(ctx.game.name).setDescription(message);
-    await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    await ctx.reply(
+      new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons))
+    );
 
     await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: SNOWBALL_FIGHT_MINIGAME_MAX_DURATION });
 
@@ -78,6 +81,8 @@ export class SnowballFightMinigame implements Minigame {
     disposeActiveTimeouts(ctx);
 
     if (!ctx.game) throw new Error("Game data missing.");
+
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
 
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
@@ -90,7 +95,9 @@ export class SnowballFightMinigame implements Minigame {
         maxDuration: SNOWBALL_FIGHT_MINIGAME_MAX_DURATION,
         failureReason: "Timeout"
       });
-      await ctx.edit(new MessageBuilder().addEmbed(embed).setComponents([]));
+      await ctx.edit(
+        new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons))
+      );
     } else {
       await minigameFinished(ctx, {
         success: true,
@@ -98,7 +105,9 @@ export class SnowballFightMinigame implements Minigame {
         maxDuration: SNOWBALL_FIGHT_MINIGAME_MAX_DURATION,
         failureReason: "Wrong button"
       });
-      await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+      await ctx.reply(
+        new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons))
+      );
     }
 
     transitionToDefaultTreeView(ctx);

--- a/src/minigames/SnowballFightMinigame.ts
+++ b/src/minigames/SnowballFightMinigame.ts
@@ -1,6 +1,6 @@
 import { ButtonContext, EmbedBuilder, MessageBuilder, ActionRowBuilder, Button, ButtonBuilder } from "interactions.ts";
 import { shuffleArray } from "../util/helpers/arrayHelper";
-import { disposeActiveTimeouts, transitionToDefaultTreeView } from "../commands/Tree";
+import { disposeActiveTimeouts, transitionToDefaultTreeView, buildTreeDisplayMessage } from "../commands/Tree";
 import { Minigame, MinigameConfig } from "../util/types/minigame/MinigameType";
 import { getPremiumUpsellMessage, minigameFinished } from "./MinigameFactory";
 import { getRandomButtonStyle } from "../util/discord/DiscordApiExtensions";
@@ -29,7 +29,8 @@ export class SnowballFightMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.snowballfight.snowball"),
       await ctx.manager.components.createInstance("minigame.snowballfight.miss-1"),
       await ctx.manager.components.createInstance("minigame.snowballfight.miss-2"),
-      await ctx.manager.components.createInstance("minigame.snowballfight.miss-3")
+      await ctx.manager.components.createInstance("minigame.snowballfight.miss-3"),
+      await ctx.manager.components.createInstance("tree.refresh")
     ];
 
     shuffleArray(buttons);

--- a/src/minigames/TinselTwisterMinigame.ts
+++ b/src/minigames/TinselTwisterMinigame.ts
@@ -50,7 +50,8 @@ export class TinselTwisterMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.tinseltwister.tinsel", { currentStage }),
       await ctx.manager.components.createInstance("minigame.tinseltwister.empty-1", { currentStage }),
       await ctx.manager.components.createInstance("minigame.tinseltwister.empty-2", { currentStage }),
-      await ctx.manager.components.createInstance("minigame.tinseltwister.empty-3", { currentStage })
+      await ctx.manager.components.createInstance("minigame.tinseltwister.empty-3", { currentStage }),
+      await ctx.manager.components.createInstance("tree.refresh")
     ];
 
     shuffleArray(buttons);
@@ -144,6 +145,21 @@ export class TinselTwisterMinigame implements Minigame {
       "minigame.tinseltwister.empty-3",
       new ButtonBuilder().setEmoji({ name: "🌲" }).setStyle(getRandomButtonStyle()),
       TinselTwisterMinigame.handleEmptyButton
+    ),
+    new Button(
+      "tree.refresh",
+      new ButtonBuilder().setEmoji({ name: "🔄" }).setStyle(2),
+      async (ctx: ButtonContext): Promise<void> => {
+        if (
+          UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) &&
+          (await BanHelper.isUserBanned(ctx.user.id))
+        ) {
+          await ctx.reply(BanHelper.getBanEmbed(ctx.user.username));
+          transitionToDefaultTreeView(ctx);
+          return;
+        }
+        return await ctx.reply(await buildTreeDisplayMessage(ctx));
+      }
     )
   ];
 }

--- a/src/minigames/TinselTwisterMinigame.ts
+++ b/src/minigames/TinselTwisterMinigame.ts
@@ -50,8 +50,7 @@ export class TinselTwisterMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.tinseltwister.tinsel", { currentStage }),
       await ctx.manager.components.createInstance("minigame.tinseltwister.empty-1", { currentStage }),
       await ctx.manager.components.createInstance("minigame.tinseltwister.empty-2", { currentStage }),
-      await ctx.manager.components.createInstance("minigame.tinseltwister.empty-3", { currentStage }),
-      await ctx.manager.components.createInstance("tree.refresh")
+      await ctx.manager.components.createInstance("minigame.tinseltwister.empty-3", { currentStage })
     ];
 
     shuffleArray(buttons);
@@ -81,11 +80,15 @@ export class TinselTwisterMinigame implements Minigame {
     ctx.game.size++;
     await ctx.game.save();
 
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription(`You completed the Tinsel Twister! Your tree has grown 1ft!`);
 
-    await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    await ctx.reply(
+      new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons))
+    );
     await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: TINSEL_TWISTER_MINIGAME_MAX_DURATION });
     transitionToDefaultTreeView(ctx as ButtonContext);
   }
@@ -106,14 +109,20 @@ export class TinselTwisterMinigame implements Minigame {
 
     if (!ctx.game) throw new Error("Game data missing.");
 
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription(`You missed the tinsel. Better luck next time!`);
 
     if (isTimeout) {
-      await ctx.edit(new MessageBuilder().addEmbed(embed).setComponents([]));
+      await ctx.edit(
+        new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons))
+      );
     } else {
-      await ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+      await ctx.reply(
+        new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons))
+      );
     }
 
     await minigameFinished(ctx, {
@@ -145,21 +154,6 @@ export class TinselTwisterMinigame implements Minigame {
       "minigame.tinseltwister.empty-3",
       new ButtonBuilder().setEmoji({ name: "🌲" }).setStyle(getRandomButtonStyle()),
       TinselTwisterMinigame.handleEmptyButton
-    ),
-    new Button(
-      "tree.refresh",
-      new ButtonBuilder().setEmoji({ name: "🔄" }).setStyle(2),
-      async (ctx: ButtonContext): Promise<void> => {
-        if (
-          UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) &&
-          (await BanHelper.isUserBanned(ctx.user.id))
-        ) {
-          await ctx.reply(BanHelper.getBanEmbed(ctx.user.username));
-          transitionToDefaultTreeView(ctx);
-          return;
-        }
-        return await ctx.reply(await buildTreeDisplayMessage(ctx));
-      }
     )
   ];
 }

--- a/src/minigames/specialDays/EarthDayCleanupMinigame.ts
+++ b/src/minigames/specialDays/EarthDayCleanupMinigame.ts
@@ -28,8 +28,7 @@ export class EarthDayCleanupMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.earthdaycleanup.trash"),
       await ctx.manager.components.createInstance("minigame.earthdaycleanup.empty-1"),
       await ctx.manager.components.createInstance("minigame.earthdaycleanup.empty-2"),
-      await ctx.manager.components.createInstance("minigame.earthdaycleanup.empty-3"),
-      await ctx.manager.components.createInstance("tree.refresh")
+      await ctx.manager.components.createInstance("minigame.earthdaycleanup.empty-3")
     ];
 
     const message = new MessageBuilder().addComponents(new ActionRowBuilder().addComponents(...buttons));
@@ -59,6 +58,8 @@ export class EarthDayCleanupMinigame implements Minigame {
     ctx.game.size += 2;
     await ctx.game.save();
 
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription("You cleaned up the environment and your tree grew 2ft taller!")
@@ -66,7 +67,7 @@ export class EarthDayCleanupMinigame implements Minigame {
         "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/earthday-cleanup/earthday-cleanup-1.jpg"
       );
 
-    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    ctx.reply(new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons)));
 
     await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: EARTH_DAY_CLEANUP_MINIGAME_MAX_DURATION });
 
@@ -77,11 +78,14 @@ export class EarthDayCleanupMinigame implements Minigame {
     disposeActiveTimeouts(ctx);
 
     if (!ctx.game) throw new Error("Game data missing.");
+
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription("You missed the trash. Better luck next time!");
 
-    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    ctx.reply(new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons)));
 
     await minigameFinished(ctx, {
       success: false,
@@ -113,21 +117,6 @@ export class EarthDayCleanupMinigame implements Minigame {
       "minigame.earthdaycleanup.empty-3",
       new ButtonBuilder().setEmoji({ name: "🗑️" }).setStyle(getRandomButtonStyle()),
       EarthDayCleanupMinigame.handleEmptyButton
-    ),
-    new Button(
-      "tree.refresh",
-      new ButtonBuilder().setEmoji({ name: "🔄" }).setStyle(2),
-      async (ctx: ButtonContext): Promise<void> => {
-        if (
-          UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) &&
-          (await BanHelper.isUserBanned(ctx.user.id))
-        ) {
-          await ctx.reply(BanHelper.getBanEmbed(ctx.user.username));
-          transitionToDefaultTreeView(ctx);
-          return;
-        }
-        return await ctx.reply(await buildTreeDisplayMessage(ctx));
-      }
     )
   ];
 }

--- a/src/minigames/specialDays/EarthDayCleanupMinigame.ts
+++ b/src/minigames/specialDays/EarthDayCleanupMinigame.ts
@@ -28,7 +28,8 @@ export class EarthDayCleanupMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.earthdaycleanup.trash"),
       await ctx.manager.components.createInstance("minigame.earthdaycleanup.empty-1"),
       await ctx.manager.components.createInstance("minigame.earthdaycleanup.empty-2"),
-      await ctx.manager.components.createInstance("minigame.earthdaycleanup.empty-3")
+      await ctx.manager.components.createInstance("minigame.earthdaycleanup.empty-3"),
+      await ctx.manager.components.createInstance("tree.refresh")
     ];
 
     const message = new MessageBuilder().addComponents(new ActionRowBuilder().addComponents(...buttons));
@@ -112,6 +113,21 @@ export class EarthDayCleanupMinigame implements Minigame {
       "minigame.earthdaycleanup.empty-3",
       new ButtonBuilder().setEmoji({ name: "🗑️" }).setStyle(getRandomButtonStyle()),
       EarthDayCleanupMinigame.handleEmptyButton
+    ),
+    new Button(
+      "tree.refresh",
+      new ButtonBuilder().setEmoji({ name: "🔄" }).setStyle(2),
+      async (ctx: ButtonContext): Promise<void> => {
+        if (
+          UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) &&
+          (await BanHelper.isUserBanned(ctx.user.id))
+        ) {
+          await ctx.reply(BanHelper.getBanEmbed(ctx.user.username));
+          transitionToDefaultTreeView(ctx);
+          return;
+        }
+        return await ctx.reply(await buildTreeDisplayMessage(ctx));
+      }
     )
   ];
 }

--- a/src/minigames/specialDays/FireworksShowMinigame.ts
+++ b/src/minigames/specialDays/FireworksShowMinigame.ts
@@ -28,7 +28,8 @@ export class FireworksShowMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.fireworksshow.firework"),
       await ctx.manager.components.createInstance("minigame.fireworksshow.empty-1"),
       await ctx.manager.components.createInstance("minigame.fireworksshow.empty-2"),
-      await ctx.manager.components.createInstance("minigame.fireworksshow.empty-3")
+      await ctx.manager.components.createInstance("minigame.fireworksshow.empty-3"),
+      await ctx.manager.components.createInstance("tree.refresh")
     ];
 
     const message = new MessageBuilder().addComponents(new ActionRowBuilder().addComponents(...buttons));
@@ -108,6 +109,21 @@ export class FireworksShowMinigame implements Minigame {
       "minigame.fireworksshow.empty-3",
       new ButtonBuilder().setEmoji({ name: "🎉" }).setStyle(getRandomButtonStyle()),
       FireworksShowMinigame.handleEmptyButton
+    ),
+    new Button(
+      "tree.refresh",
+      new ButtonBuilder().setEmoji({ name: "🔄" }).setStyle(2),
+      async (ctx: ButtonContext): Promise<void> => {
+        if (
+          UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) &&
+          (await BanHelper.isUserBanned(ctx.user.id))
+        ) {
+          await ctx.reply(BanHelper.getBanEmbed(ctx.user.username));
+          transitionToDefaultTreeView(ctx);
+          return;
+        }
+        return await ctx.reply(await buildTreeDisplayMessage(ctx));
+      }
     )
   ];
 }

--- a/src/minigames/specialDays/FireworksShowMinigame.ts
+++ b/src/minigames/specialDays/FireworksShowMinigame.ts
@@ -28,8 +28,7 @@ export class FireworksShowMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.fireworksshow.firework"),
       await ctx.manager.components.createInstance("minigame.fireworksshow.empty-1"),
       await ctx.manager.components.createInstance("minigame.fireworksshow.empty-2"),
-      await ctx.manager.components.createInstance("minigame.fireworksshow.empty-3"),
-      await ctx.manager.components.createInstance("tree.refresh")
+      await ctx.manager.components.createInstance("minigame.fireworksshow.empty-3")
     ];
 
     const message = new MessageBuilder().addComponents(new ActionRowBuilder().addComponents(...buttons));
@@ -59,6 +58,8 @@ export class FireworksShowMinigame implements Minigame {
     ctx.game.size += 2;
     await ctx.game.save();
 
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription("You launched a spectacular fireworks show! Your tree grew 2ft taller!")
@@ -66,7 +67,7 @@ export class FireworksShowMinigame implements Minigame {
         "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/newyears-eve/newyears-eve-2.jpg"
       );
 
-    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    ctx.reply(new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons)));
     await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: FIREWORKS_SHOW_MINIGAME_MAX_DURATION });
     transitionToDefaultTreeView(ctx);
   }
@@ -75,11 +76,14 @@ export class FireworksShowMinigame implements Minigame {
     disposeActiveTimeouts(ctx);
 
     if (!ctx.game) throw new Error("Game data missing.");
+
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription("You missed the fireworks. Better luck next time!");
 
-    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    ctx.reply(new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons)));
     await minigameFinished(ctx, {
       success: false,
       difficulty: 1,
@@ -109,21 +113,6 @@ export class FireworksShowMinigame implements Minigame {
       "minigame.fireworksshow.empty-3",
       new ButtonBuilder().setEmoji({ name: "🎉" }).setStyle(getRandomButtonStyle()),
       FireworksShowMinigame.handleEmptyButton
-    ),
-    new Button(
-      "tree.refresh",
-      new ButtonBuilder().setEmoji({ name: "🔄" }).setStyle(2),
-      async (ctx: ButtonContext): Promise<void> => {
-        if (
-          UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) &&
-          (await BanHelper.isUserBanned(ctx.user.id))
-        ) {
-          await ctx.reply(BanHelper.getBanEmbed(ctx.user.username));
-          transitionToDefaultTreeView(ctx);
-          return;
-        }
-        return await ctx.reply(await buildTreeDisplayMessage(ctx));
-      }
     )
   ];
 }

--- a/src/minigames/specialDays/HeartCollectionMinigame.ts
+++ b/src/minigames/specialDays/HeartCollectionMinigame.ts
@@ -28,7 +28,8 @@ export class HeartCollectionMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.heartcollection.heart"),
       await ctx.manager.components.createInstance("minigame.heartcollection.empty-1"),
       await ctx.manager.components.createInstance("minigame.heartcollection.empty-2"),
-      await ctx.manager.components.createInstance("minigame.heartcollection.empty-3")
+      await ctx.manager.components.createInstance("minigame.heartcollection.empty-3"),
+      await ctx.manager.components.createInstance("tree.refresh")
     ];
 
     const message = new MessageBuilder().addComponents(new ActionRowBuilder().addComponents(...buttons));

--- a/src/minigames/specialDays/HeartCollectionMinigame.ts
+++ b/src/minigames/specialDays/HeartCollectionMinigame.ts
@@ -28,8 +28,7 @@ export class HeartCollectionMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.heartcollection.heart"),
       await ctx.manager.components.createInstance("minigame.heartcollection.empty-1"),
       await ctx.manager.components.createInstance("minigame.heartcollection.empty-2"),
-      await ctx.manager.components.createInstance("minigame.heartcollection.empty-3"),
-      await ctx.manager.components.createInstance("tree.refresh")
+      await ctx.manager.components.createInstance("minigame.heartcollection.empty-3")
     ];
 
     const message = new MessageBuilder().addComponents(new ActionRowBuilder().addComponents(...buttons));
@@ -59,6 +58,8 @@ export class HeartCollectionMinigame implements Minigame {
     ctx.game.size += 2;
     await ctx.game.save();
 
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription("You collected hearts and your tree grew 2ft taller!")
@@ -66,7 +67,7 @@ export class HeartCollectionMinigame implements Minigame {
         "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/valentine-day/valentine-day-3.jpg"
       );
 
-    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    ctx.reply(new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons)));
     await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: HEART_COLLECTION_MINIGAME_MAX_DURATION });
     transitionToDefaultTreeView(ctx);
   }
@@ -75,11 +76,14 @@ export class HeartCollectionMinigame implements Minigame {
     disposeActiveTimeouts(ctx);
 
     if (!ctx.game) throw new Error("Game data missing.");
+
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription("You missed the hearts. Better luck next time!");
 
-    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    ctx.reply(new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons)));
     await minigameFinished(ctx, {
       success: false,
       difficulty: 1,

--- a/src/minigames/specialDays/PumpkinHuntMinigame.ts
+++ b/src/minigames/specialDays/PumpkinHuntMinigame.ts
@@ -28,7 +28,8 @@ export class PumpkinHuntMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.pumpkinhunt.pumpkin"),
       await ctx.manager.components.createInstance("minigame.pumpkinhunt.empty-1"),
       await ctx.manager.components.createInstance("minigame.pumpkinhunt.empty-2"),
-      await ctx.manager.components.createInstance("minigame.pumpkinhunt.empty-3")
+      await ctx.manager.components.createInstance("minigame.pumpkinhunt.empty-3"),
+      await ctx.manager.components.createInstance("tree.refresh")
     ];
 
     const message = new MessageBuilder().addComponents(new ActionRowBuilder().addComponents(...buttons));
@@ -106,6 +107,21 @@ export class PumpkinHuntMinigame implements Minigame {
       "minigame.pumpkinhunt.empty-3",
       new ButtonBuilder().setEmoji({ name: "🕸️" }).setStyle(getRandomButtonStyle()),
       PumpkinHuntMinigame.handleEmptyButton
+    ),
+    new Button(
+      "tree.refresh",
+      new ButtonBuilder().setEmoji({ name: "🔄" }).setStyle(2),
+      async (ctx: ButtonContext): Promise<void> => {
+        if (
+          UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) &&
+          (await BanHelper.isUserBanned(ctx.user.id))
+        ) {
+          await ctx.reply(BanHelper.getBanEmbed(ctx.user.username));
+          transitionToDefaultTreeView(ctx);
+          return;
+        }
+        return await ctx.reply(await buildTreeDisplayMessage(ctx));
+      }
     )
   ];
 }

--- a/src/minigames/specialDays/PumpkinHuntMinigame.ts
+++ b/src/minigames/specialDays/PumpkinHuntMinigame.ts
@@ -28,8 +28,7 @@ export class PumpkinHuntMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.pumpkinhunt.pumpkin"),
       await ctx.manager.components.createInstance("minigame.pumpkinhunt.empty-1"),
       await ctx.manager.components.createInstance("minigame.pumpkinhunt.empty-2"),
-      await ctx.manager.components.createInstance("minigame.pumpkinhunt.empty-3"),
-      await ctx.manager.components.createInstance("tree.refresh")
+      await ctx.manager.components.createInstance("minigame.pumpkinhunt.empty-3")
     ];
 
     const message = new MessageBuilder().addComponents(new ActionRowBuilder().addComponents(...buttons));
@@ -59,12 +58,14 @@ export class PumpkinHuntMinigame implements Minigame {
     ctx.game.size += 2;
     await ctx.game.save();
 
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription("You found a hidden pumpkin and your tree grew 2ft taller!")
       .setImage("https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/halloween/halloween-2.jpg");
 
-    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    ctx.reply(new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons)));
     await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: PUMPKIN_HUNT_MINIGAME_MAX_DURATION });
     transitionToDefaultTreeView(ctx);
   }
@@ -73,11 +74,14 @@ export class PumpkinHuntMinigame implements Minigame {
     disposeActiveTimeouts(ctx);
 
     if (!ctx.game) throw new Error("Game data missing.");
+
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription("You missed the pumpkins. Better luck next time!");
 
-    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    ctx.reply(new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons)));
     await minigameFinished(ctx, {
       success: false,
       difficulty: 1,
@@ -107,21 +111,6 @@ export class PumpkinHuntMinigame implements Minigame {
       "minigame.pumpkinhunt.empty-3",
       new ButtonBuilder().setEmoji({ name: "🕸️" }).setStyle(getRandomButtonStyle()),
       PumpkinHuntMinigame.handleEmptyButton
-    ),
-    new Button(
-      "tree.refresh",
-      new ButtonBuilder().setEmoji({ name: "🔄" }).setStyle(2),
-      async (ctx: ButtonContext): Promise<void> => {
-        if (
-          UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) &&
-          (await BanHelper.isUserBanned(ctx.user.id))
-        ) {
-          await ctx.reply(BanHelper.getBanEmbed(ctx.user.username));
-          transitionToDefaultTreeView(ctx);
-          return;
-        }
-        return await ctx.reply(await buildTreeDisplayMessage(ctx));
-      }
     )
   ];
 }

--- a/src/minigames/specialDays/StPatricksDayTreasureHuntMinigame.ts
+++ b/src/minigames/specialDays/StPatricksDayTreasureHuntMinigame.ts
@@ -28,7 +28,8 @@ export class StPatricksDayTreasureHuntMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.stpatrickstreasurehunt.treasure"),
       await ctx.manager.components.createInstance("minigame.stpatrickstreasurehunt.empty-1"),
       await ctx.manager.components.createInstance("minigame.stpatrickstreasurehunt.empty-2"),
-      await ctx.manager.components.createInstance("minigame.stpatrickstreasurehunt.empty-3")
+      await ctx.manager.components.createInstance("minigame.stpatrickstreasurehunt.empty-3"),
+      await ctx.manager.components.createInstance("tree.refresh")
     ];
 
     const message = new MessageBuilder().addComponents(new ActionRowBuilder().addComponents(...buttons));
@@ -112,6 +113,21 @@ export class StPatricksDayTreasureHuntMinigame implements Minigame {
       "minigame.stpatrickstreasurehunt.empty-3",
       new ButtonBuilder().setEmoji({ name: "🍃" }).setStyle(getRandomButtonStyle()),
       StPatricksDayTreasureHuntMinigame.handleEmptyButton
+    ),
+    new Button(
+      "tree.refresh",
+      new ButtonBuilder().setEmoji({ name: "🔄" }).setStyle(2),
+      async (ctx: ButtonContext): Promise<void> => {
+        if (
+          UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) &&
+          (await BanHelper.isUserBanned(ctx.user.id))
+        ) {
+          await ctx.reply(BanHelper.getBanEmbed(ctx.user.username));
+          transitionToDefaultTreeView(ctx);
+          return;
+        }
+        return await ctx.reply(await buildTreeDisplayMessage(ctx));
+      }
     )
   ];
 }

--- a/src/minigames/specialDays/StPatricksDayTreasureHuntMinigame.ts
+++ b/src/minigames/specialDays/StPatricksDayTreasureHuntMinigame.ts
@@ -28,8 +28,7 @@ export class StPatricksDayTreasureHuntMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.stpatrickstreasurehunt.treasure"),
       await ctx.manager.components.createInstance("minigame.stpatrickstreasurehunt.empty-1"),
       await ctx.manager.components.createInstance("minigame.stpatrickstreasurehunt.empty-2"),
-      await ctx.manager.components.createInstance("minigame.stpatrickstreasurehunt.empty-3"),
-      await ctx.manager.components.createInstance("tree.refresh")
+      await ctx.manager.components.createInstance("minigame.stpatrickstreasurehunt.empty-3")
     ];
 
     const message = new MessageBuilder().addComponents(new ActionRowBuilder().addComponents(...buttons));
@@ -59,6 +58,8 @@ export class StPatricksDayTreasureHuntMinigame implements Minigame {
     ctx.game.size += 2;
     await ctx.game.save();
 
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription("You found a hidden treasure and your tree grew 2ft taller!")
@@ -66,7 +67,7 @@ export class StPatricksDayTreasureHuntMinigame implements Minigame {
         "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/st-patricks-day/st-patricks-day-1.jpg"
       );
 
-    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    ctx.reply(new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons)));
     await minigameFinished(ctx, {
       success: true,
       difficulty: 1,
@@ -79,11 +80,14 @@ export class StPatricksDayTreasureHuntMinigame implements Minigame {
     disposeActiveTimeouts(ctx);
 
     if (!ctx.game) throw new Error("Game data missing.");
+
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription("You missed the treasures. Better luck next time!");
 
-    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    ctx.reply(new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons)));
     await minigameFinished(ctx, {
       success: false,
       difficulty: 1,
@@ -113,21 +117,6 @@ export class StPatricksDayTreasureHuntMinigame implements Minigame {
       "minigame.stpatrickstreasurehunt.empty-3",
       new ButtonBuilder().setEmoji({ name: "🍃" }).setStyle(getRandomButtonStyle()),
       StPatricksDayTreasureHuntMinigame.handleEmptyButton
-    ),
-    new Button(
-      "tree.refresh",
-      new ButtonBuilder().setEmoji({ name: "🔄" }).setStyle(2),
-      async (ctx: ButtonContext): Promise<void> => {
-        if (
-          UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) &&
-          (await BanHelper.isUserBanned(ctx.user.id))
-        ) {
-          await ctx.reply(BanHelper.getBanEmbed(ctx.user.username));
-          transitionToDefaultTreeView(ctx);
-          return;
-        }
-        return await ctx.reply(await buildTreeDisplayMessage(ctx));
-      }
     )
   ];
 }

--- a/src/minigames/specialDays/ThanksgivingFeastMinigame.ts
+++ b/src/minigames/specialDays/ThanksgivingFeastMinigame.ts
@@ -30,7 +30,8 @@ export class ThanksgivingFeastMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.thanksgivingfeast.feast"),
       await ctx.manager.components.createInstance("minigame.thanksgivingfeast.empty-1"),
       await ctx.manager.components.createInstance("minigame.thanksgivingfeast.empty-2"),
-      await ctx.manager.components.createInstance("minigame.thanksgivingfeast.empty-3")
+      await ctx.manager.components.createInstance("minigame.thanksgivingfeast.empty-3"),
+      await ctx.manager.components.createInstance("tree.refresh")
     ];
 
     const message = new MessageBuilder().addComponents(new ActionRowBuilder().addComponents(...buttons));
@@ -114,6 +115,21 @@ export class ThanksgivingFeastMinigame implements Minigame {
       "minigame.thanksgivingfeast.empty-3",
       new ButtonBuilder().setEmoji({ name: "🥄" }).setStyle(getRandomButtonStyle()),
       ThanksgivingFeastMinigame.handleEmptyButton
+    ),
+    new Button(
+      "tree.refresh",
+      new ButtonBuilder().setEmoji({ name: "🔄" }).setStyle(2),
+      async (ctx: ButtonContext): Promise<void> => {
+        if (
+          UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) &&
+          (await BanHelper.isUserBanned(ctx.user.id))
+        ) {
+          await ctx.reply(BanHelper.getBanEmbed(ctx.user.username));
+          transitionToDefaultTreeView(ctx);
+          return;
+        }
+        return await ctx.reply(await buildTreeDisplayMessage(ctx));
+      }
     )
   ];
 }

--- a/src/minigames/specialDays/ThanksgivingFeastMinigame.ts
+++ b/src/minigames/specialDays/ThanksgivingFeastMinigame.ts
@@ -30,8 +30,7 @@ export class ThanksgivingFeastMinigame implements Minigame {
       await ctx.manager.components.createInstance("minigame.thanksgivingfeast.feast"),
       await ctx.manager.components.createInstance("minigame.thanksgivingfeast.empty-1"),
       await ctx.manager.components.createInstance("minigame.thanksgivingfeast.empty-2"),
-      await ctx.manager.components.createInstance("minigame.thanksgivingfeast.empty-3"),
-      await ctx.manager.components.createInstance("tree.refresh")
+      await ctx.manager.components.createInstance("minigame.thanksgivingfeast.empty-3")
     ];
 
     const message = new MessageBuilder().addComponents(new ActionRowBuilder().addComponents(...buttons));
@@ -61,6 +60,8 @@ export class ThanksgivingFeastMinigame implements Minigame {
     ctx.game.size += 2;
     await ctx.game.save();
 
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription("You prepared a delicious Thanksgiving feast and your tree grew 2ft taller!")
@@ -68,7 +69,7 @@ export class ThanksgivingFeastMinigame implements Minigame {
         "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/minigame/thanks-giving/thanks-giving-3.jpg"
       );
 
-    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    ctx.reply(new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons)));
     await minigameFinished(ctx, {
       success: true,
       difficulty: 1,
@@ -81,11 +82,14 @@ export class ThanksgivingFeastMinigame implements Minigame {
     disposeActiveTimeouts(ctx);
 
     if (!ctx.game) throw new Error("Game data missing.");
+
+    const buttons = [await ctx.manager.components.createInstance("minigame.refresh")];
+
     const embed = new EmbedBuilder()
       .setTitle(ctx.game.name)
       .setDescription("You missed the feast. Better luck next time!");
 
-    ctx.reply(new MessageBuilder().addEmbed(embed).setComponents([]));
+    ctx.reply(new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons)));
     await minigameFinished(ctx, {
       success: false,
       difficulty: 1,
@@ -115,21 +119,6 @@ export class ThanksgivingFeastMinigame implements Minigame {
       "minigame.thanksgivingfeast.empty-3",
       new ButtonBuilder().setEmoji({ name: "🥄" }).setStyle(getRandomButtonStyle()),
       ThanksgivingFeastMinigame.handleEmptyButton
-    ),
-    new Button(
-      "tree.refresh",
-      new ButtonBuilder().setEmoji({ name: "🔄" }).setStyle(2),
-      async (ctx: ButtonContext): Promise<void> => {
-        if (
-          UnleashHelper.isEnabled(UNLEASH_FEATURES.banEnforcement, ctx) &&
-          (await BanHelper.isUserBanned(ctx.user.id))
-        ) {
-          await ctx.reply(BanHelper.getBanEmbed(ctx.user.username));
-          transitionToDefaultTreeView(ctx);
-          return;
-        }
-        return await ctx.reply(await buildTreeDisplayMessage(ctx));
-      }
     )
   ];
 }


### PR DESCRIPTION
Fixes #113

Add a refresh button to all minigames to return to the tree view.

* **Minigame Files**: Add a refresh button to the minigames `CarolingChoirMinigame.ts`, `GiftUnwrappingMinigame.ts`, `GrinchHeistMinigame.ts`, `HolidayCookieCountdownMinigame.ts`, `HotCocoaMinigame.ts`, `SantaPresentMinigame.ts`, `SnowballFightMinigame.ts`, `EarthDayCleanupMinigame.ts`, `FireworksShowMinigame.ts`, `HeartCollectionMinigame.ts`, `PumpkinHuntMinigame.ts`, `StPatricksDayTreasureHuntMinigame.ts`, `ThanksgivingFeastMinigame.ts`, and `TinselTwisterMinigame.ts`.
* **MinigameFactory.ts**: Add the `tree.refresh` button to the minigame buttons array.
* **Button Handling**: Add button handling for the `tree.refresh` button in the minigame files to invoke the `transitionToDefaultTreeView` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GewoonJaap/grow-a-christmas-tree/pull/114?shareId=105cd669-2ca9-4de6-9121-8d6ecfb7e039).