### PR TITLE
Add limited-time styles to the cosmetics shop

### DIFF
--- a/src/util/api/image-styles/ImageStyleApi.ts
+++ b/src/util/api/image-styles/ImageStyleApi.ts
@@ -66,6 +66,18 @@ export class ImageStylesApi {
     }
   }
 
+  public async getLimitedTimeStyles(): Promise<ImageStylesReponse> {
+    try {
+      const response = await fetch(`${this.apiUrl}/api/styles/limited-time`, {
+        method: "GET"
+      });
+      return await response.json();
+    } catch (error) {
+      console.error(error);
+      return { success: false, styles: [] };
+    }
+  }
+
   private isCacheValid(cachedData: CachedResponse<unknown> | undefined): boolean {
     if (!cachedData) return false;
     return cachedData.expiresAt > Date.now();

--- a/src/util/news/NewsMessageHelper.ts
+++ b/src/util/news/NewsMessageHelper.ts
@@ -18,6 +18,11 @@ export class NewsMessageHelper {
     "🎉 **Happy New Year!** 🎆 Wishing you a magical year ahead! To kick off 2024, we're gifting extra coins, boosters, and tickets today! Plus, enjoy 25% more on item purchases in the shop! 🎁🎊"
   ];
 
+  private static limitedTimeStyleMessages: string[] = [
+    "🎉 **Congratulations!** You've claimed a new limited-time style: **[Style Name]**! 🎄",
+    "🌟 Check out your new style in the cosmetics shop and make your tree even more magical! ✨"
+  ];
+
   /**
    * Get news messages, including special day messages
    * @param maxMessages The maximum number of messages to return. Note it might contain more messages if there are special day messages
@@ -50,5 +55,11 @@ export class NewsMessageHelper {
       messages.push(getRandomElement(this.newYearMessages) ?? this.newYearMessages[0]);
     }
     return messages;
+  }
+
+  public static getLimitedTimeStyleMessage(styleName: string): string {
+    return this.limitedTimeStyleMessages
+      .map((message) => message.replace("[Style Name]", styleName))
+      .join("\n");
   }
 }


### PR DESCRIPTION
Fixes #124

Add limited-time styles to the cosmetics shop and allow users to claim them.

* Add a button for claiming limited-time styles in `src/commands/shop/categories/Cosmetics.ts`.
* Fetch limited-time styles from the API and return an extra array in `src/commands/shop/categories/Cosmetics.ts`.
* Display limited-time styles in the cosmetics shop in `src/commands/shop/categories/Cosmetics.ts`.
* Check if the user meets the requirements when claiming a limited-time style in `src/commands/shop/categories/Cosmetics.ts`.
* Add the claimed style to the user's unlocked tree styles in `src/commands/shop/categories/Cosmetics.ts`.
* Add a method to fetch limited-time styles from the API in `src/util/api/image-styles/ImageStyleApi.ts`.
* Announce claimed limited-time styles in the news messages in `src/util/news/NewsMessageHelper.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GewoonJaap/grow-a-christmas-tree/pull/125?shareId=89dfb786-98e7-45f2-a9ed-a1283590e104).