### PR TITLE
Fix purchase command spelling

### DIFF
--- a/src/commands/About.ts
+++ b/src/commands/About.ts
@@ -49,7 +49,7 @@ export class About implements ISlashCommand {
         👤 **/profile** - View your profile and the amount of coins you have.
         📖 **/dailyreward** - Claim your daily supply of free coins.
         🎁 **/adventcalendar** - Open your daily advent calendar present.
-        🪙 **/redeempurschages** - Redeem any outstanding purchases from the shop.
+        🪙 **/redeempurchases** - Redeem any outstanding purchases from the shop.
         💸 **/sendcoins** - Transfer coins to another player.
         🛒 **/shop** - Browse and grab magical items from the shop to power up your tree!
 

--- a/src/commands/Composter.ts
+++ b/src/commands/Composter.ts
@@ -257,7 +257,7 @@ function transitionBackToDefaultComposterViewWithTimeout(ctx: ButtonContext, del
 
 function coinUpsell(upgradeCost: number): MessageUpsellType {
   const needMoreCoins =
-    "🎅 Need more coins? Play minigames after watering, claim your daily reward or purschage more coins in the store";
+    "🎅 Need more coins? Play minigames after watering, claim your daily reward or purchase more coins in the store";
   if (upgradeCost <= 500) {
     return {
       message: needMoreCoins,

--- a/src/commands/RedeemPurchases.ts
+++ b/src/commands/RedeemPurchases.ts
@@ -31,11 +31,11 @@ import { WheelStateHelper } from "../util/wheel/WheelStateHelper";
 import { BoosterHelper, BoosterName } from "../util/booster/BoosterHelper";
 import { SpecialDayHelper } from "../util/special-days/SpecialDayHelper";
 
-const builder = new SlashCommandBuilder("redeempurschages", "Redeem all your purchases from the shop");
+const builder = new SlashCommandBuilder("redeempurchases", "Redeem all your purchases from the shop");
 
 builder.setDMEnabled(false);
 
-export class RedeemPurschagesCommand implements ISlashCommand {
+export class RedeemPurchasesCommand implements ISlashCommand {
   public builder = builder;
 
   public handler = async (ctx: SlashCommandContext): Promise<void> => {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -8,7 +8,7 @@ export * from "./Tree";
 export * from "./Recycle";
 export * from "./NotificationSettings";
 export * from "./SendCoins";
-export * from "./RedeemPurschages";
+export * from "./RedeemPurchases";
 export * from "./DailyReward";
 export * from "./Composter";
 export * from "./shop/index";


### PR DESCRIPTION
Fixes #143

Correct the spelling of "purschages" to "purchases" in various files.

* **src/commands/index.ts**
  - Rename the command `RedeemPurschages` to `RedeemPurchases`
  - Update the import statement to reflect the new file name `RedeemPurchases`
* **src/commands/RedeemPurschages.ts** (renamed to `src/commands/RedeemPurchases.ts`)
  - Rename the file to `RedeemPurchases.ts`
  - Rename the class `RedeemPurschagesCommand` to `RedeemPurchasesCommand`
  - Update the command name from `redeempurschages` to `redeempurchases`
  - Update the description to "Redeem all your purchases from the shop"
* **src/commands/Composter.ts**
  - Update the function `coinUpsell` to replace "purschage" with "purchase"
* **src/commands/About.ts**
  - Update the command reference from `/redeempurschages` to `/redeempurchases`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GewoonJaap/grow-a-christmas-tree/pull/144?shareId=dfc81316-a509-4b36-8d45-9a96adf91917).