### PR TITLE
Fix redeem purchases to only consume consumable SKUs

### DIFF
--- a/src/commands/RedeemPurchases.ts
+++ b/src/commands/RedeemPurchases.ts
@@ -76,7 +76,7 @@ async function buildRedeemCoinsMessage(ctx: SlashCommandContext | ButtonContext)
 
   for (const entitlement of entitlements) {
     const reward = SKU_REWARDS[entitlement.sku_id as SKU];
-    if (!reward) {
+    if (!reward || !reward.isConsumable) {
       console.error(`No reward found for SKU ${entitlement.sku_id}`);
       continue;
     }

--- a/src/commands/RedeemPurchases.ts
+++ b/src/commands/RedeemPurchases.ts
@@ -75,13 +75,13 @@ async function buildRedeemCoinsMessage(ctx: SlashCommandContext | ButtonContext)
   const boostersToApply: BoosterName[] = [];
 
   for (const entitlement of entitlements) {
-    const success = await consumeEntitlement(entitlement.id);
+    const reward = SKU_REWARDS[entitlement.sku_id as SKU];
+    if (!reward) {
+      console.error(`No reward found for SKU ${entitlement.sku_id}`);
+      continue;
+    }
+    const success = await consumeEntitlement(entitlement.id, entitlement.sku_id as SKU);
     if (success) {
-      const reward = SKU_REWARDS[entitlement.sku_id as SKU];
-      if (!reward) {
-        console.error(`No reward found for SKU ${entitlement.sku_id}`);
-        continue;
-      }
       totalCoins += reward.coins;
       totalLuckyTickets += reward.luckyTickets;
       if (reward.booster) {

--- a/src/util/discord/DiscordApiExtensions.ts
+++ b/src/util/discord/DiscordApiExtensions.ts
@@ -24,6 +24,7 @@ export type SKURewardType = {
   coins: number;
   luckyTickets: number;
   booster: BoosterName | undefined;
+  isConsumable: boolean;
 };
 
 export type SKURewardsType = {
@@ -31,15 +32,28 @@ export type SKURewardsType = {
 };
 
 export const SKU_REWARDS: SKURewardsType = {
-  [SKU.SMALL_POUCH_OF_COINS]: { coins: 500, luckyTickets: 0, booster: undefined },
-  [SKU.GOLDEN_COIN_STASH]: { coins: 5000, luckyTickets: 0, booster: undefined },
-  [SKU.LUCKY_COIN_BAG]: { coins: 1500, luckyTickets: 0, booster: undefined },
-  [SKU.TREASURE_CHEST_OF_COINS]: { coins: 3000, luckyTickets: 0, booster: undefined },
-  [SKU.HOLIDAY_LUCKY_TICKET]: { coins: 0, luckyTickets: 10, booster: undefined },
-  [SKU.LUCKY_TICKET_25]: { coins: 0, luckyTickets: 25, booster: undefined },
-  [SKU.LUCKY_TICKET_50]: { coins: 0, luckyTickets: 50, booster: undefined },
-  [SKU.GOLDEN_COIN_STASH_WATERING_BOOSTER]: { coins: 5000, luckyTickets: 0, booster: "Watering Booster" },
-  [SKU.TREASURE_CHEST_OF_COINS_WATERING_BOOSTER]: { coins: 3000, luckyTickets: 0, booster: "Watering Booster" }
+  [SKU.FESTIVE_ENTITLEMENT]: { coins: 0, luckyTickets: 0, booster: undefined, isConsumable: false },
+  [SKU.SUPER_THIRSTY_ENTITLEMENT]: { coins: 0, luckyTickets: 0, booster: undefined, isConsumable: false },
+  [SKU.SUPER_THIRSTY_2_ENTITLEMENT]: { coins: 0, luckyTickets: 0, booster: undefined, isConsumable: false },
+  [SKU.SMALL_POUCH_OF_COINS]: { coins: 500, luckyTickets: 0, booster: undefined, isConsumable: true },
+  [SKU.GOLDEN_COIN_STASH]: { coins: 5000, luckyTickets: 0, booster: undefined, isConsumable: true },
+  [SKU.LUCKY_COIN_BAG]: { coins: 1500, luckyTickets: 0, booster: undefined, isConsumable: true },
+  [SKU.TREASURE_CHEST_OF_COINS]: { coins: 3000, luckyTickets: 0, booster: undefined, isConsumable: true },
+  [SKU.HOLIDAY_LUCKY_TICKET]: { coins: 0, luckyTickets: 10, booster: undefined, isConsumable: true },
+  [SKU.LUCKY_TICKET_25]: { coins: 0, luckyTickets: 25, booster: undefined, isConsumable: true },
+  [SKU.LUCKY_TICKET_50]: { coins: 0, luckyTickets: 50, booster: undefined, isConsumable: true },
+  [SKU.GOLDEN_COIN_STASH_WATERING_BOOSTER]: {
+    coins: 5000,
+    luckyTickets: 0,
+    booster: "Watering Booster",
+    isConsumable: true
+  },
+  [SKU.TREASURE_CHEST_OF_COINS_WATERING_BOOSTER]: {
+    coins: 3000,
+    luckyTickets: 0,
+    booster: "Watering Booster",
+    isConsumable: true
+  }
 };
 
 export function getEntitlements(
@@ -142,19 +156,7 @@ export function getRandomButtonStyle(): ButtonStyle {
 }
 
 export async function consumeEntitlement(entitlementId: string, skuId: SKU): Promise<boolean> {
-  const consumableSkus = [
-    SKU.SMALL_POUCH_OF_COINS,
-    SKU.GOLDEN_COIN_STASH,
-    SKU.LUCKY_COIN_BAG,
-    SKU.TREASURE_CHEST_OF_COINS,
-    SKU.HOLIDAY_LUCKY_TICKET,
-    SKU.LUCKY_TICKET_25,
-    SKU.LUCKY_TICKET_50,
-    SKU.GOLDEN_COIN_STASH_WATERING_BOOSTER,
-    SKU.TREASURE_CHEST_OF_COINS_WATERING_BOOSTER
-  ];
-
-  if (!consumableSkus.includes(skuId)) {
+  if (!SKU_REWARDS[skuId].isConsumable) {
     return false;
   }
 

--- a/src/util/discord/DiscordApiExtensions.ts
+++ b/src/util/discord/DiscordApiExtensions.ts
@@ -31,9 +31,6 @@ export type SKURewardsType = {
 };
 
 export const SKU_REWARDS: SKURewardsType = {
-  [SKU.FESTIVE_ENTITLEMENT]: { coins: 0, luckyTickets: 0, booster: undefined },
-  [SKU.SUPER_THIRSTY_ENTITLEMENT]: { coins: 0, luckyTickets: 0, booster: undefined },
-  [SKU.SUPER_THIRSTY_2_ENTITLEMENT]: { coins: 0, luckyTickets: 0, booster: undefined },
   [SKU.SMALL_POUCH_OF_COINS]: { coins: 500, luckyTickets: 0, booster: undefined },
   [SKU.GOLDEN_COIN_STASH]: { coins: 5000, luckyTickets: 0, booster: undefined },
   [SKU.LUCKY_COIN_BAG]: { coins: 1500, luckyTickets: 0, booster: undefined },
@@ -144,7 +141,23 @@ export function getRandomButtonStyle(): ButtonStyle {
   return (Math.floor(Math.random() * 4) + 1) as ButtonStyle;
 }
 
-export async function consumeEntitlement(entitlementId: string): Promise<boolean> {
+export async function consumeEntitlement(entitlementId: string, skuId: SKU): Promise<boolean> {
+  const consumableSkus = [
+    SKU.SMALL_POUCH_OF_COINS,
+    SKU.GOLDEN_COIN_STASH,
+    SKU.LUCKY_COIN_BAG,
+    SKU.TREASURE_CHEST_OF_COINS,
+    SKU.HOLIDAY_LUCKY_TICKET,
+    SKU.LUCKY_TICKET_25,
+    SKU.LUCKY_TICKET_50,
+    SKU.GOLDEN_COIN_STASH_WATERING_BOOSTER,
+    SKU.TREASURE_CHEST_OF_COINS_WATERING_BOOSTER
+  ];
+
+  if (!consumableSkus.includes(skuId)) {
+    return false;
+  }
+
   const url = `https://discord.com/api/v10/applications/${process.env.CLIENT_ID}/entitlements/${entitlementId}/consume`;
   const response = await axios.post(
     url,

--- a/src/util/discord/DiscordWebhookEvents.ts
+++ b/src/util/discord/DiscordWebhookEvents.ts
@@ -9,19 +9,7 @@ export async function handleEntitlementCreate(data: EntitlementCreateData) {
   const skuId = data.sku_id as SKU;
   const reward = SKU_REWARDS[skuId];
 
-  const consumableSkus = [
-    SKU.SMALL_POUCH_OF_COINS,
-    SKU.GOLDEN_COIN_STASH,
-    SKU.LUCKY_COIN_BAG,
-    SKU.TREASURE_CHEST_OF_COINS,
-    SKU.HOLIDAY_LUCKY_TICKET,
-    SKU.LUCKY_TICKET_25,
-    SKU.LUCKY_TICKET_50,
-    SKU.GOLDEN_COIN_STASH_WATERING_BOOSTER,
-    SKU.TREASURE_CHEST_OF_COINS_WATERING_BOOSTER
-  ];
-
-  if (reward && !reward.booster && consumableSkus.includes(skuId)) {
+  if (reward && !reward.booster && reward.isConsumable) {
     await consumeEntitlement(data.id, skuId);
 
     if (reward.coins > 0) {

--- a/src/util/discord/DiscordWebhookEvents.ts
+++ b/src/util/discord/DiscordWebhookEvents.ts
@@ -9,9 +9,20 @@ export async function handleEntitlementCreate(data: EntitlementCreateData) {
   const skuId = data.sku_id as SKU;
   const reward = SKU_REWARDS[skuId];
 
-  if (reward && !reward.booster) {
-    // Booster rewards are server bound and thus not supported this way
-    await consumeEntitlement(data.id);
+  const consumableSkus = [
+    SKU.SMALL_POUCH_OF_COINS,
+    SKU.GOLDEN_COIN_STASH,
+    SKU.LUCKY_COIN_BAG,
+    SKU.TREASURE_CHEST_OF_COINS,
+    SKU.HOLIDAY_LUCKY_TICKET,
+    SKU.LUCKY_TICKET_25,
+    SKU.LUCKY_TICKET_50,
+    SKU.GOLDEN_COIN_STASH_WATERING_BOOSTER,
+    SKU.TREASURE_CHEST_OF_COINS_WATERING_BOOSTER
+  ];
+
+  if (reward && !reward.booster && consumableSkus.includes(skuId)) {
+    await consumeEntitlement(data.id, skuId);
 
     if (reward.coins > 0) {
       await WalletHelper.addCoins(userId, reward.coins);


### PR DESCRIPTION
Fixes #150

Update code to only consume consumable SKUs, excluding Festive forest and super thirsty.

* Modify `src/util/discord/DiscordApiExtensions.ts` to add a check in `consumeEntitlement` to only consume consumable SKUs and update `SKU_REWARDS` to exclude non-consumable SKUs.
* Update `src/commands/RedeemPurchases.ts` to only call `consumeEntitlement` for consumable SKUs.
* Modify `src/util/discord/DiscordWebhookEvents.ts` to only consume consumable SKUs.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GewoonJaap/grow-a-christmas-tree/pull/151?shareId=4cbedf4c-a220-40af-a8d6-eb53180f471b).