### PR TITLE
Use OpenTelemetry for Mongoose

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.55.0",
+    "@opentelemetry/instrumentation-mongoose": "^0.46.0",
     "@types/node": "^22.5.5",
     "@types/node-fetch": "^2.6.1",
     "@typescript-eslint/eslint-plugin": "^5.17.0",

--- a/src/tracing/metrics.ts
+++ b/src/tracing/metrics.ts
@@ -69,4 +69,12 @@ export class Metrics {
 
     adventCalendarWinMetric.add(1, { user: userId, reward: rewardDetails });
   }
+
+  static recordMongooseOperationMetric(operation: string, duration: number): void {
+    const mongooseOperationMetric = meter.createHistogram("mongoose_operations", {
+      description: "Records the duration of Mongoose operations"
+    });
+
+    mongooseOperationMetric.record(duration, { operation });
+  }
 }

--- a/src/tracing/sdk.ts
+++ b/src/tracing/sdk.ts
@@ -5,6 +5,7 @@ import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import { Resource } from "@opentelemetry/resources";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
+import { MongooseInstrumentation } from '@opentelemetry/instrumentation-mongoose';
 
 // Common resource attributes
 const resource = new Resource({
@@ -30,7 +31,7 @@ const metricReader = new PeriodicExportingMetricReader({
 // SDK setup
 const sdk = new NodeSDK({
   traceExporter,
-  instrumentations: [getNodeAutoInstrumentations()],
+  instrumentations: [getNodeAutoInstrumentations(), new MongooseInstrumentation()],
   resource: resource
 });
 


### PR DESCRIPTION
Add OpenTelemetry instrumentation for Mongoose.

* **`src/tracing/sdk.ts`**
  - Import `MongooseInstrumentation` from `@opentelemetry/instrumentation-mongoose`.
  - Add `new MongooseInstrumentation()` to the `instrumentations` array in the `NodeSDK` setup.

* **`src/tracing/metrics.ts`**
  - Add a method `recordMongooseOperationMetric` to record metrics for Mongoose operations.

* **`package.json`**
  - Add `@opentelemetry/instrumentation-mongoose` to the `devDependencies`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GewoonJaap/grow-a-christmas-tree/pull/173?shareId=ba3475f1-47d3-4568-871f-0c8147a21abe).