### PR TITLE
Add OpenTelemetry integration for logging and metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "interactions.ts": "^1.0.23",
     "mongoose": "^8.0.1",
     "pino": "^9.5.0",
+    "pino-pretty": "^13.0.0",
     "redis": "^4.1.0",
     "tweetnacl": "^1.0.3",
     "unleash-client": "^6.1.3"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   "author": "ssMMiles",
   "license": "MIT",
   "dependencies": {
+    "@opentelemetry/instrumentation-pino": "^0.46.0",
+    "@opentelemetry/instrumentation-undici": "^0.10.0",
     "@types/humanize-duration": "^3.27.1",
     "axios": "^1.6.2",
     "dotenv": "^16.0.0",
@@ -24,6 +26,7 @@
     "humanize-duration": "^3.27.3",
     "interactions.ts": "^1.0.23",
     "mongoose": "^8.0.1",
+    "pino": "^9.5.0",
     "redis": "^4.1.0",
     "tweetnacl": "^1.0.3",
     "unleash-client": "^6.1.3"

--- a/src/backup/backup.ts
+++ b/src/backup/backup.ts
@@ -2,7 +2,11 @@ import { Guild, IGuild } from "../models/Guild";
 import { readFileSync, readdirSync, writeFileSync } from "fs";
 import { unlinkSync } from "fs";
 import path = require("path");
-import { logger } from "../tracing/pinoLogger";
+import pino from "pino";
+
+const logger = pino({
+  level: "info"
+});
 
 let backupTimerStarted = false;
 

--- a/src/backup/backup.ts
+++ b/src/backup/backup.ts
@@ -2,6 +2,7 @@ import { Guild, IGuild } from "../models/Guild";
 import { readFileSync, readdirSync, writeFileSync } from "fs";
 import { unlinkSync } from "fs";
 import path = require("path");
+import { logger } from "../tracing/pinoLogger";
 
 let backupTimerStarted = false;
 
@@ -37,7 +38,7 @@ async function createBackup() {
 
     removeOldBackups();
   } catch (err) {
-    console.error(err);
+    logger.error(err);
   }
 }
 
@@ -63,7 +64,7 @@ async function removeOldBackups() {
           unlinkSync(filePath);
         }
       } catch (err) {
-        console.error(err);
+        logger.error(err);
       }
     }
   });

--- a/src/commands/Composter.ts
+++ b/src/commands/Composter.ts
@@ -20,6 +20,7 @@ import { PremiumButtonBuilder, SKU } from "../util/discord/DiscordApiExtensions"
 import { safeEdit, safeReply } from "../util/discord/MessageExtenstions";
 import { SpecialDayHelper } from "../util/special-days/SpecialDayHelper";
 import { logger } from "../tracing/pinoLogger";
+import { Metrics } from "../tracing/metrics";
 
 const BASE_COST = 100;
 const COST_INCREMENT = 50;
@@ -219,6 +220,13 @@ async function handleUpgrade(ctx: ButtonContext, upgradeType: "efficiency" | "qu
     if (coinUpsellData.isUpsell && coinUpsellData.buttonSku && !process.env.DEV_MODE) {
       actions.addComponents(new PremiumButtonBuilder().setSkuId(coinUpsellData.buttonSku));
     }
+
+    Metrics.recordComposterUpgradeMetric(
+      ctx.user.id,
+      ctx.game.id,
+      upgradeType,
+      upgradeType === "efficiency" ? efficiencyLevel : qualityLevel
+    );
 
     const message = new MessageBuilder().addEmbed(embed).addComponents(actions);
 

--- a/src/commands/Composter.ts
+++ b/src/commands/Composter.ts
@@ -19,6 +19,7 @@ import { UnleashHelper, UNLEASH_FEATURES } from "../util/unleash/UnleashHelper";
 import { PremiumButtonBuilder, SKU } from "../util/discord/DiscordApiExtensions";
 import { safeEdit, safeReply } from "../util/discord/MessageExtenstions";
 import { SpecialDayHelper } from "../util/special-days/SpecialDayHelper";
+import { logger } from "../tracing/pinoLogger";
 
 const BASE_COST = 100;
 const COST_INCREMENT = 50;
@@ -249,7 +250,7 @@ function transitionBackToDefaultComposterViewWithTimeout(ctx: ButtonContext, del
 
         await safeEdit(ctx, await buildComposterMessage(ctx));
       } catch (e) {
-        console.log(e);
+        logger.info(e);
       }
     }, delay)
   );

--- a/src/commands/Composter.ts
+++ b/src/commands/Composter.ts
@@ -19,9 +19,12 @@ import { UnleashHelper, UNLEASH_FEATURES } from "../util/unleash/UnleashHelper";
 import { PremiumButtonBuilder, SKU } from "../util/discord/DiscordApiExtensions";
 import { safeEdit, safeReply } from "../util/discord/MessageExtenstions";
 import { SpecialDayHelper } from "../util/special-days/SpecialDayHelper";
-import { logger } from "../tracing/pinoLogger";
 import { Metrics } from "../tracing/metrics";
+import pino from "pino";
 
+const logger = pino({
+  level: "info"
+});
 const BASE_COST = 100;
 const COST_INCREMENT = 50;
 const MAX_LEVEL = 100;

--- a/src/commands/RedeemPurchases.ts
+++ b/src/commands/RedeemPurchases.ts
@@ -17,6 +17,7 @@ import { BoosterHelper, BoosterName } from "../util/booster/BoosterHelper";
 import { SpecialDayHelper } from "../util/special-days/SpecialDayHelper";
 import { safeReply } from "../util/discord/MessageExtenstions";
 import { Metrics } from "../tracing/metrics"; // Import Metrics
+import { logger } from "../tracing/pinoLogger";
 
 const builder = new SlashCommandBuilder("redeempurchases", "Redeem all your purchases from the shop");
 
@@ -83,7 +84,7 @@ async function buildRedeemCoinsMessage(ctx: SlashCommandContext | ButtonContext)
   for (const entitlement of consumableEntitlements) {
     const reward = SKU_REWARDS[entitlement.sku_id as SKU];
     if (!reward) {
-      console.error(`No reward found for SKU ${entitlement.sku_id}`);
+      logger.error(`No reward found for SKU ${entitlement.sku_id}`);
       continue;
     }
     const success = await consumeEntitlement(entitlement.id, entitlement.sku_id as SKU);

--- a/src/commands/RedeemPurchases.ts
+++ b/src/commands/RedeemPurchases.ts
@@ -17,7 +17,11 @@ import { BoosterHelper, BoosterName } from "../util/booster/BoosterHelper";
 import { SpecialDayHelper } from "../util/special-days/SpecialDayHelper";
 import { safeReply } from "../util/discord/MessageExtenstions";
 import { Metrics } from "../tracing/metrics"; // Import Metrics
-import { logger } from "../tracing/pinoLogger";
+import pino from "pino";
+
+const logger = pino({
+  level: "info"
+});
 
 const builder = new SlashCommandBuilder("redeempurchases", "Redeem all your purchases from the shop");
 

--- a/src/commands/SendCoins.ts
+++ b/src/commands/SendCoins.ts
@@ -14,6 +14,7 @@ import { WalletHelper } from "../util/wallet/WalletHelper";
 import { BanHelper } from "../util/bans/BanHelper";
 import { UnleashHelper, UNLEASH_FEATURES } from "../util/unleash/UnleashHelper";
 import { safeReply } from "../util/discord/MessageExtenstions";
+import { logger } from "../tracing/pinoLogger";
 
 const builder = new SlashCommandBuilder("sendcoins", "Transfer coins to another player.")
   .addUserOption(new SlashCommandUserOption("recipient", "The player to transfer coins to.").setRequired(true))
@@ -97,7 +98,7 @@ export class SendCoinsCommand implements ISlashCommand {
     await safeReply(ctx, new MessageBuilder().addEmbed(embed));
 
     // Log the transfer details for auditing purposes
-    console.log(
+    logger.info(
       `Coin Transfer: Sender: ${
         ctx.user.id
       }, Recipient: ${recipientId}, Amount: ${amount}, Timestamp: ${new Date().toISOString()}`

--- a/src/commands/SendCoins.ts
+++ b/src/commands/SendCoins.ts
@@ -15,6 +15,7 @@ import { BanHelper } from "../util/bans/BanHelper";
 import { UnleashHelper, UNLEASH_FEATURES } from "../util/unleash/UnleashHelper";
 import { safeReply } from "../util/discord/MessageExtenstions";
 import { logger } from "../tracing/pinoLogger";
+import { Metrics } from "../tracing/metrics";
 
 const builder = new SlashCommandBuilder("sendcoins", "Transfer coins to another player.")
   .addUserOption(new SlashCommandUserOption("recipient", "The player to transfer coins to.").setRequired(true))
@@ -94,6 +95,8 @@ export class SendCoinsCommand implements ISlashCommand {
           ctx.game.hasAiAccess ? "" : " Premium servers earn more coins, have access to more minigames and much more!"
         }`
       });
+
+    Metrics.recordSendCoinsMetric(sender.userId, recipient.userId, amount);
 
     await safeReply(ctx, new MessageBuilder().addEmbed(embed));
 

--- a/src/commands/SendCoins.ts
+++ b/src/commands/SendCoins.ts
@@ -14,8 +14,12 @@ import { WalletHelper } from "../util/wallet/WalletHelper";
 import { BanHelper } from "../util/bans/BanHelper";
 import { UnleashHelper, UNLEASH_FEATURES } from "../util/unleash/UnleashHelper";
 import { safeReply } from "../util/discord/MessageExtenstions";
-import { logger } from "../tracing/pinoLogger";
 import { Metrics } from "../tracing/metrics";
+import pino from "pino";
+
+const logger = pino({
+  level: "info"
+});
 
 const builder = new SlashCommandBuilder("sendcoins", "Transfer coins to another player.")
   .addUserOption(new SlashCommandUserOption("recipient", "The player to transfer coins to.").setRequired(true))

--- a/src/commands/Styles.ts
+++ b/src/commands/Styles.ts
@@ -18,6 +18,7 @@ import { randomUUID } from "crypto";
 import { permissionsExtractor } from "../util/bitfield-permission-calculator";
 import { disposeActiveTimeouts } from "./Tree";
 import { safeReply, safeEdit } from "../util/discord/MessageExtenstions";
+import { logger } from "../tracing/pinoLogger";
 
 const STYLES_PER_PAGE = 25;
 
@@ -197,7 +198,7 @@ export class Styles implements ISlashCommand {
           disposeActiveTimeouts(ctx);
           await safeEdit(ctx, await this.buildStylesMessage(ctx));
         } catch (e) {
-          console.log(e);
+          logger.info(e);
         }
       }, delay)
     );

--- a/src/commands/Styles.ts
+++ b/src/commands/Styles.ts
@@ -18,7 +18,11 @@ import { randomUUID } from "crypto";
 import { permissionsExtractor } from "../util/bitfield-permission-calculator";
 import { disposeActiveTimeouts } from "./Tree";
 import { safeReply, safeEdit } from "../util/discord/MessageExtenstions";
-import { logger } from "../tracing/pinoLogger";
+import pino from "pino";
+
+const logger = pino({
+  level: "info"
+});
 
 const STYLES_PER_PAGE = 25;
 

--- a/src/commands/Tree.ts
+++ b/src/commands/Tree.ts
@@ -27,6 +27,7 @@ import { getLocaleFromTimezone } from "../util/timezones";
 import { NewsMessageHelper } from "../util/news/NewsMessageHelper";
 import { BoosterHelper } from "../util/booster/BoosterHelper";
 import { safeReply, safeEdit } from "../util/discord/MessageExtenstions";
+import { logger } from "../tracing/pinoLogger";
 
 const MINIGAME_CHANCE = 0.4;
 const MINIGAME_DELAY_SECONDS = 5 * 60;
@@ -235,12 +236,12 @@ export function transitionToDefaultTreeView(ctx: ButtonContext | ButtonContext<u
         disposeActiveTimeouts(ctx);
         await safeEdit(ctx, await buildTreeDisplayMessage(ctx));
       } catch (e) {
-        console.error(e);
+        logger.error(e);
         try {
           //One last retry
           await safeEdit(ctx, await buildTreeDisplayMessage(ctx));
         } catch (e) {
-          console.error(e);
+          logger.error(e);
         }
       }
     }, delay)

--- a/src/commands/shop/categories/Boosters.ts
+++ b/src/commands/shop/categories/Boosters.ts
@@ -16,8 +16,12 @@ import humanizeDuration = require("humanize-duration");
 import { PartialCommand } from "../../../util/types/command/PartialCommandType";
 import { safeReply, safeEdit } from "../../../util/discord/MessageExtenstions";
 import { PremiumButtons } from "../../../util/buttons/PremiumButtons";
-import { logger } from "../../../tracing/pinoLogger";
 import { Metrics } from "../../../tracing/metrics";
+import pino from "pino";
+
+const logger = pino({
+  level: "info"
+});
 
 const IMAGES = [
   "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/shop/shop-1.jpg",

--- a/src/commands/shop/categories/Boosters.ts
+++ b/src/commands/shop/categories/Boosters.ts
@@ -17,6 +17,7 @@ import { PartialCommand } from "../../../util/types/command/PartialCommandType";
 import { safeReply, safeEdit } from "../../../util/discord/MessageExtenstions";
 import { PremiumButtons } from "../../../util/buttons/PremiumButtons";
 import { logger } from "../../../tracing/pinoLogger";
+import { Metrics } from "../../../tracing/metrics";
 
 const IMAGES = [
   "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/shop/shop-1.jpg",
@@ -218,6 +219,8 @@ export class Boosters implements PartialCommand {
     const actionRow = new ActionRowBuilder().addComponents(
       await ctx.manager.components.createInstance("shop.boosters.refresh")
     );
+
+    Metrics.recordBoosterPurchaseMetric(booster.name, ctx.user.id, ctx.game.id);
 
     const embed = new EmbedBuilder()
       .setTitle("🎁 Purchase Complete!")

--- a/src/commands/shop/categories/Boosters.ts
+++ b/src/commands/shop/categories/Boosters.ts
@@ -16,6 +16,7 @@ import humanizeDuration = require("humanize-duration");
 import { PartialCommand } from "../../../util/types/command/PartialCommandType";
 import { safeReply, safeEdit } from "../../../util/discord/MessageExtenstions";
 import { PremiumButtons } from "../../../util/buttons/PremiumButtons";
+import { logger } from "../../../tracing/pinoLogger";
 
 const IMAGES = [
   "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/shop/shop-1.jpg",
@@ -240,7 +241,7 @@ export class Boosters implements PartialCommand {
 
           await safeEdit(ctx, await this.buildBoostersMessage(ctx));
         } catch (e) {
-          console.log(e);
+          logger.info(e);
         }
       }, delay)
     );

--- a/src/commands/shop/categories/Cosmetics.ts
+++ b/src/commands/shop/categories/Cosmetics.ts
@@ -24,7 +24,11 @@ import { getLocaleFromTimezone } from "../../../util/timezones";
 import { safeReply, safeEdit } from "../../../util/discord/MessageExtenstions";
 import { SpecialDayHelper } from "../../../util/special-days/SpecialDayHelper";
 import { Metrics } from "../../../tracing/metrics"; // Import Metrics
-import { logger } from "../../../tracing/pinoLogger";
+import pino from "pino";
+
+const logger = pino({
+  level: "info"
+});
 
 const IMAGES = [
   "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/shop/shop-1.jpg",

--- a/src/commands/shop/categories/Cosmetics.ts
+++ b/src/commands/shop/categories/Cosmetics.ts
@@ -304,7 +304,7 @@ export class Cosmetics implements PartialCommand, DynamicButtonsCommandType {
     await TreeStyleHelper.addNewStyle(ctx, styleName);
 
     // Log item name and other relevant details when a cosmetic purchase is made
-    Metrics.recordCosmeticPurchaseMetric(styleName, ctx.user.id, ctx.interaction.guild_id ?? ctx.game?.id);
+    Metrics.recordCosmeticPurchaseMetric(styleName, ctx.user.id, ctx.interaction.guild_id ?? ctx.game?.id ?? "Unknown");
 
     const embed = await this.getTreeStyleEmbed(styleName);
 

--- a/src/commands/shop/categories/Cosmetics.ts
+++ b/src/commands/shop/categories/Cosmetics.ts
@@ -24,6 +24,7 @@ import { getLocaleFromTimezone } from "../../../util/timezones";
 import { safeReply, safeEdit } from "../../../util/discord/MessageExtenstions";
 import { SpecialDayHelper } from "../../../util/special-days/SpecialDayHelper";
 import { Metrics } from "../../../tracing/metrics"; // Import Metrics
+import { logger } from "../../../tracing/pinoLogger";
 
 const IMAGES = [
   "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/shop/shop-1.jpg",
@@ -366,7 +367,7 @@ export class Cosmetics implements PartialCommand, DynamicButtonsCommandType {
     const allStyle = [...festiveStyles, ...flatItemShop];
 
     if (!itemShopStyles.fromCache) {
-      console.log("Refreshing item shop styles...");
+      logger.info("Refreshing item shop styles...");
       await this.unregisterStyleButtons(componentManager, allStyle);
       await this.registerStyleButtons(componentManager, allStyle);
     }
@@ -382,7 +383,7 @@ export class Cosmetics implements PartialCommand, DynamicButtonsCommandType {
           disposeActiveTimeouts(ctx);
           await safeEdit(ctx, await this.buildCosmeticsMessage(ctx));
         } catch (e) {
-          console.log(e);
+          logger.info(e);
         }
       }, delay)
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ import { DynamicButtonsCommandType } from "./util/types/command/DynamicButtonsCo
 import { runMigrations } from "./migrations";
 import { safeReply } from "./util/discord/MessageExtenstions";
 import { Metrics } from "./tracing/metrics";
-import { logger } from "./tracing/pinoLogger";
+import { logger } from "./tracing/sdk";
 
 const VERSION = "2.0";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,6 @@ import "dotenv/config";
 
 // Import and initialize telemetry and metrics
 import "./tracing/sdk";
-import pino from "pino";
-
-const logger = pino({
-  level: process.env.LOG_LEVEL || 'info',
-  prettyPrint: { colorize: true }
-});
 
 import fastify from "fastify";
 import rawBody from "fastify-raw-body";
@@ -63,10 +57,11 @@ import { DynamicButtonsCommandType } from "./util/types/command/DynamicButtonsCo
 import { runMigrations } from "./migrations";
 import { safeReply } from "./util/discord/MessageExtenstions";
 import { Metrics } from "./tracing/metrics";
+import { logger } from "./tracing/pinoLogger";
 
 const VERSION = "2.0";
 
-unleash.on("ready", console.log.bind(console, "Unleash ready"));
+unleash.on("ready", logger.info.bind(logger, "Unleash ready"));
 
 declare module "interactions.ts" {
   interface BaseInteractionContext {
@@ -218,7 +213,7 @@ if (keys.some((key) => !(key in process.env))) {
         err instanceof UnknownComponentType
       ) {
         logger.error("Unknown Interaction - Library may be out of date.");
-        logger.dir(err.interaction);
+        logger.error(err.interaction);
 
         return reply.code(400).send();
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,11 @@ import { DynamicButtonsCommandType } from "./util/types/command/DynamicButtonsCo
 import { runMigrations } from "./migrations";
 import { safeReply } from "./util/discord/MessageExtenstions";
 import { Metrics } from "./tracing/metrics";
-import { logger } from "./tracing/sdk";
+import pino from "pino";
+
+const logger = pino({
+  level: "info"
+});
 
 const VERSION = "2.0";
 

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,4 +1,8 @@
-import { logger } from "../tracing/pinoLogger";
+import pino from "pino";
+
+const logger = pino({
+  level: "info"
+});
 
 export async function runMigrations(): Promise<void> {
   logger.info("Running migrations...");

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,4 +1,6 @@
+import { logger } from "../tracing/pinoLogger";
+
 export async function runMigrations(): Promise<void> {
-  console.log("Running migrations...");
-  console.log("Migrations completed.");
+  logger.info("Running migrations...");
+  logger.info("Migrations completed.");
 }

--- a/src/minigames/CarolingChoirMinigame.ts
+++ b/src/minigames/CarolingChoirMinigame.ts
@@ -70,7 +70,8 @@ export class CarolingChoirMinigame implements Minigame {
         success: false,
         difficulty: 1,
         maxDuration: CAROLING_CHOIR_MINIGAME_MAX_DURATION,
-        failureReason: "Timeout"
+        failureReason: "Timeout",
+        minigameName: "Caroling Choir"
       });
       await safeEdit(ctx, await buildTreeDisplayMessage(ctx as ButtonContext));
     }, CAROLING_CHOIR_MINIGAME_MAX_DURATION);
@@ -99,7 +100,8 @@ export class CarolingChoirMinigame implements Minigame {
     await minigameFinished(ctx as ButtonContext, {
       success: true,
       difficulty: 1,
-      maxDuration: CAROLING_CHOIR_MINIGAME_MAX_DURATION
+      maxDuration: CAROLING_CHOIR_MINIGAME_MAX_DURATION,
+      minigameName: "Caroling Choir"
     });
   }
 
@@ -133,7 +135,8 @@ export class CarolingChoirMinigame implements Minigame {
       success: false,
       difficulty: 1,
       maxDuration: CAROLING_CHOIR_MINIGAME_MAX_DURATION,
-      failureReason: "Wrong button"
+      failureReason: "Wrong button",
+      minigameName: "Caroling Choir"
     });
   }
 

--- a/src/minigames/GiftUnwrappingMinigame.ts
+++ b/src/minigames/GiftUnwrappingMinigame.ts
@@ -46,7 +46,8 @@ export class GiftUnwrappingMinigame implements Minigame {
         success: false,
         difficulty: 1,
         maxDuration: GIFT_UNWRAPPING_MINIGAME_MAX_DURATION,
-        failureReason: "Timeout"
+        failureReason: "Timeout",
+        minigameName: "Gift Unwrapping"
       });
       await safeEdit(ctx, await buildTreeDisplayMessage(ctx));
     }, GIFT_UNWRAPPING_MINIGAME_MAX_DURATION);
@@ -89,7 +90,12 @@ export class GiftUnwrappingMinigame implements Minigame {
 
     transitionToDefaultTreeView(ctx);
 
-    await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: GIFT_UNWRAPPING_MINIGAME_MAX_DURATION });
+    await minigameFinished(ctx, {
+      success: true,
+      difficulty: 1,
+      maxDuration: GIFT_UNWRAPPING_MINIGAME_MAX_DURATION,
+      minigameName: "Gift Unwrapping"
+    });
   }
 
   private static async handleEmptyBoxButton(ctx: ButtonContext): Promise<void> {
@@ -113,7 +119,8 @@ export class GiftUnwrappingMinigame implements Minigame {
       success: false,
       difficulty: 1,
       maxDuration: GIFT_UNWRAPPING_MINIGAME_MAX_DURATION,
-      failureReason: "Wrong button"
+      failureReason: "Wrong button",
+      minigameName: "Gift Unwrapping"
     });
   }
 

--- a/src/minigames/GrinchHeistMinigame.ts
+++ b/src/minigames/GrinchHeistMinigame.ts
@@ -111,7 +111,8 @@ export class GrinchHeistMinigame implements Minigame {
         success: false,
         difficulty: 1,
         maxDuration: GRINCH_HEIST_MINIGAME_MAX_DURATION,
-        failureReason: "Timeout"
+        failureReason: "Timeout",
+        minigameName: "Grinch Heist"
       });
       await safeEdit(
         ctx,
@@ -122,7 +123,8 @@ export class GrinchHeistMinigame implements Minigame {
         success: false,
         difficulty: 1,
         maxDuration: GRINCH_HEIST_MINIGAME_MAX_DURATION,
-        failureReason: "Wrong button"
+        failureReason: "Wrong button",
+        minigameName: "Grinch Heist"
       });
       await safeReply(
         ctx,
@@ -167,7 +169,8 @@ export class GrinchHeistMinigame implements Minigame {
           success: true,
           difficulty: 1,
           maxDuration: GRINCH_HEIST_MINIGAME_MAX_DURATION,
-          penalty: ctx.state?.isPenalty ?? false
+          penalty: ctx.state?.isPenalty ?? false,
+          minigameName: "Grinch Heist"
         });
       }
     ),

--- a/src/minigames/HolidayCookieCountdownMinigame.ts
+++ b/src/minigames/HolidayCookieCountdownMinigame.ts
@@ -89,7 +89,8 @@ export class HolidayCookieCountdownMinigame implements Minigame {
     await minigameFinished(ctx, {
       success: true,
       difficulty: 1,
-      maxDuration: HOLIDAY_COOKIE_COUNTDOWN_MINIGAME_MAX_DURATION
+      maxDuration: HOLIDAY_COOKIE_COUNTDOWN_MINIGAME_MAX_DURATION,
+      minigameName: "Holiday Cookie Countdown"
     });
 
     transitionToDefaultTreeView(ctx as ButtonContext);
@@ -123,7 +124,8 @@ export class HolidayCookieCountdownMinigame implements Minigame {
         success: false,
         difficulty: 1,
         maxDuration: HOLIDAY_COOKIE_COUNTDOWN_MINIGAME_MAX_DURATION,
-        failureReason: "Timeout"
+        failureReason: "Timeout",
+        minigameName: "Holiday Cookie Countdown"
       });
     } else {
       await safeReply(
@@ -134,7 +136,8 @@ export class HolidayCookieCountdownMinigame implements Minigame {
         success: false,
         difficulty: 1,
         maxDuration: HOLIDAY_COOKIE_COUNTDOWN_MINIGAME_MAX_DURATION,
-        failureReason: "Wrong button"
+        failureReason: "Wrong button",
+        minigameName: "Holiday Cookie Countdown"
       });
     }
 

--- a/src/minigames/HotCocoaMinigame.ts
+++ b/src/minigames/HotCocoaMinigame.ts
@@ -47,7 +47,8 @@ export class HotCocoaMinigame implements Minigame {
         success: false,
         difficulty: 1,
         maxDuration: HOT_COCOA_MINIGAME_MAX_DURATION,
-        failureReason: "Timeout"
+        failureReason: "Timeout",
+        minigameName: "Hot Cocoa Making"
       });
 
       await safeEdit(ctx, await buildTreeDisplayMessage(ctx));
@@ -76,7 +77,8 @@ export class HotCocoaMinigame implements Minigame {
       success: false,
       difficulty: 1,
       maxDuration: HOT_COCOA_MINIGAME_MAX_DURATION,
-      failureReason: "Wrong button"
+      failureReason: "Wrong button",
+      minigameName: "Hot Cocoa Making"
     });
 
     transitionToDefaultTreeView(ctx);
@@ -104,7 +106,12 @@ export class HotCocoaMinigame implements Minigame {
           ctx,
           new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons))
         );
-        await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: HOT_COCOA_MINIGAME_MAX_DURATION });
+        await minigameFinished(ctx, {
+          success: true,
+          difficulty: 1,
+          maxDuration: HOT_COCOA_MINIGAME_MAX_DURATION,
+          minigameName: "Hot Cocoa Making"
+        });
 
         transitionToDefaultTreeView(ctx);
       }

--- a/src/minigames/MinigameFactory.ts
+++ b/src/minigames/MinigameFactory.ts
@@ -25,6 +25,7 @@ import { BoosterHelper } from "../util/booster/BoosterHelper";
 import { SantaSleighRideMinigame } from "./SantaSleighRideMinigame";
 import { safeReply } from "../util/discord/MessageExtenstions";
 import { SpecialDayHelper } from "../util/special-days/SpecialDayHelper";
+import { logger } from "../tracing/pinoLogger";
 
 export interface MinigameEndedType {
   success: boolean;
@@ -163,12 +164,12 @@ export function getPremiumUpsellMessage(ctx: ButtonContext, textSuffix = "\n", a
 export async function startPenaltyMinigame(ctx: ButtonContext): Promise<boolean> {
   if (UnleashHelper.isEnabled(UNLEASH_FEATURES.antiAutoClickerPenalty, ctx)) {
     try {
-      console.log(`Starting penalty minigame for user ${ctx.user.id}`);
+      logger.info(`Starting penalty minigame for user ${ctx.user.id}`);
       const minigame = new GrinchHeistMinigame();
       await minigame.start(ctx, true);
       return true;
     } catch (error) {
-      console.error(error);
+      logger.error(error);
       return false;
     }
   }
@@ -210,7 +211,7 @@ export async function minigameFinished(
   data: MinigameEndedType
 ): Promise<void> {
   if (data.penalty) {
-    console.log(
+    logger.info(
       `Penalty minigame finished for user ${ctx.user.id}, success: ${data.success}, reason: ${data.failureReason}`
     );
   }

--- a/src/minigames/MinigameFactory.ts
+++ b/src/minigames/MinigameFactory.ts
@@ -26,6 +26,7 @@ import { SantaSleighRideMinigame } from "./SantaSleighRideMinigame";
 import { safeReply } from "../util/discord/MessageExtenstions";
 import { SpecialDayHelper } from "../util/special-days/SpecialDayHelper";
 import { logger } from "../tracing/pinoLogger";
+import { Metrics } from "../tracing/metrics";
 
 export interface MinigameEndedType {
   success: boolean;
@@ -33,6 +34,7 @@ export interface MinigameEndedType {
   maxDuration: number;
   failureReason?: string;
   penalty?: boolean;
+  minigameName: string;
 }
 
 export const minigameButtons = [
@@ -220,6 +222,9 @@ export async function minigameFinished(
   }
   if (!data.success) {
     await logFailedMinigameAttempt(ctx, data.failureReason ?? "Unknown");
+    Metrics.recordMinigameLossMetric(ctx.user.id, data.minigameName);
+  } else {
+    Metrics.recordMinigameWinMetric(ctx.user.id, data.minigameName);
   }
 }
 

--- a/src/minigames/MinigameFactory.ts
+++ b/src/minigames/MinigameFactory.ts
@@ -25,8 +25,12 @@ import { BoosterHelper } from "../util/booster/BoosterHelper";
 import { SantaSleighRideMinigame } from "./SantaSleighRideMinigame";
 import { safeReply } from "../util/discord/MessageExtenstions";
 import { SpecialDayHelper } from "../util/special-days/SpecialDayHelper";
-import { logger } from "../tracing/pinoLogger";
 import { Metrics } from "../tracing/metrics";
+import pino from "pino";
+
+const logger = pino({
+  level: "info"
+});
 
 export interface MinigameEndedType {
   success: boolean;

--- a/src/minigames/SantaPresentMinigame.ts
+++ b/src/minigames/SantaPresentMinigame.ts
@@ -49,7 +49,8 @@ export class SantaPresentMinigame implements Minigame {
         success: false,
         difficulty: 1,
         maxDuration: SANTA_MINIGAME_MAX_DURATION,
-        failureReason: "Timeout"
+        failureReason: "Timeout",
+        minigameName: "Santa Present"
       });
       await safeEdit(ctx, await buildTreeDisplayMessage(ctx));
     }, SANTA_MINIGAME_MAX_DURATION);
@@ -76,7 +77,12 @@ export class SantaPresentMinigame implements Minigame {
       new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons))
     );
 
-    await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: SANTA_MINIGAME_MAX_DURATION });
+    await minigameFinished(ctx, {
+      success: true,
+      difficulty: 1,
+      maxDuration: SANTA_MINIGAME_MAX_DURATION,
+      minigameName: "Santa Present"
+    });
 
     transitionToDefaultTreeView(ctx);
   }
@@ -102,7 +108,8 @@ export class SantaPresentMinigame implements Minigame {
       success: false,
       difficulty: 1,
       maxDuration: SANTA_MINIGAME_MAX_DURATION,
-      failureReason: "Wrong button"
+      failureReason: "Wrong button",
+      minigameName: "Santa Present"
     });
 
     transitionToDefaultTreeView(ctx);

--- a/src/minigames/SantaSleighRideMinigame.ts
+++ b/src/minigames/SantaSleighRideMinigame.ts
@@ -75,7 +75,8 @@ export class SantaSleighRideMinigame implements Minigame {
         success: false,
         difficulty: 1,
         maxDuration: SANTA_SLEIGH_RIDE_MINIGAME_MAX_DURATION,
-        failureReason: "Timeout"
+        failureReason: "Timeout",
+        minigameName: "Santa's Sleigh Ride"
       });
       await safeEdit(ctx, await buildTreeDisplayMessage(ctx as ButtonContext));
     }, SANTA_SLEIGH_RIDE_MINIGAME_MAX_DURATION);
@@ -114,7 +115,8 @@ export class SantaSleighRideMinigame implements Minigame {
     await minigameFinished(ctx as ButtonContext, {
       success: true,
       difficulty: 1,
-      maxDuration: SANTA_SLEIGH_RIDE_MINIGAME_MAX_DURATION
+      maxDuration: SANTA_SLEIGH_RIDE_MINIGAME_MAX_DURATION,
+      minigameName: "Santa's Sleigh Ride"
     });
   }
 
@@ -148,7 +150,8 @@ export class SantaSleighRideMinigame implements Minigame {
       success: false,
       difficulty: 1,
       maxDuration: SANTA_SLEIGH_RIDE_MINIGAME_MAX_DURATION,
-      failureReason: "Wrong button"
+      failureReason: "Wrong button",
+      minigameName: "Santa's Sleigh Ride"
     });
   }
 

--- a/src/minigames/SnowballFightMinigame.ts
+++ b/src/minigames/SnowballFightMinigame.ts
@@ -74,7 +74,12 @@ export class SnowballFightMinigame implements Minigame {
       new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons))
     );
 
-    await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: SNOWBALL_FIGHT_MINIGAME_MAX_DURATION });
+    await minigameFinished(ctx, {
+      success: true,
+      difficulty: 1,
+      maxDuration: SNOWBALL_FIGHT_MINIGAME_MAX_DURATION,
+      minigameName: "Snowball Fight"
+    });
 
     transitionToDefaultTreeView(ctx);
   }
@@ -95,7 +100,8 @@ export class SnowballFightMinigame implements Minigame {
         success: true,
         difficulty: 1,
         maxDuration: SNOWBALL_FIGHT_MINIGAME_MAX_DURATION,
-        failureReason: "Timeout"
+        failureReason: "Timeout",
+        minigameName: "Snowball Fight"
       });
       await safeEdit(
         ctx,
@@ -106,7 +112,8 @@ export class SnowballFightMinigame implements Minigame {
         success: true,
         difficulty: 1,
         maxDuration: SNOWBALL_FIGHT_MINIGAME_MAX_DURATION,
-        failureReason: "Wrong button"
+        failureReason: "Wrong button",
+        minigameName: "Snowball Fight"
       });
       await safeReply(
         ctx,

--- a/src/minigames/TinselTwisterMinigame.ts
+++ b/src/minigames/TinselTwisterMinigame.ts
@@ -68,7 +68,8 @@ export class TinselTwisterMinigame implements Minigame {
         success: false,
         difficulty: 1,
         maxDuration: TINSEL_TWISTER_MINIGAME_MAX_DURATION,
-        failureReason: "Timeout"
+        failureReason: "Timeout",
+        minigameName: "Tinsel Twister"
       });
       await safeEdit(ctx, await buildTreeDisplayMessage(ctx as ButtonContext));
     }, TINSEL_TWISTER_MINIGAME_MAX_DURATION);
@@ -91,7 +92,12 @@ export class TinselTwisterMinigame implements Minigame {
       ctx,
       new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons))
     );
-    await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: TINSEL_TWISTER_MINIGAME_MAX_DURATION });
+    await minigameFinished(ctx, {
+      success: true,
+      difficulty: 1,
+      maxDuration: TINSEL_TWISTER_MINIGAME_MAX_DURATION,
+      minigameName: "Tinsel Twister"
+    });
     transitionToDefaultTreeView(ctx as ButtonContext);
   }
 
@@ -133,7 +139,8 @@ export class TinselTwisterMinigame implements Minigame {
       success: false,
       difficulty: 1,
       maxDuration: TINSEL_TWISTER_MINIGAME_MAX_DURATION,
-      failureReason: "Wrong button"
+      failureReason: "Wrong button",
+      minigameName: "Tinsel Twister"
     });
     transitionToDefaultTreeView(ctx as ButtonContext);
   }

--- a/src/minigames/specialDays/EarthDayCleanupMinigame.ts
+++ b/src/minigames/specialDays/EarthDayCleanupMinigame.ts
@@ -44,7 +44,8 @@ export class EarthDayCleanupMinigame implements Minigame {
         success: false,
         difficulty: 1,
         maxDuration: EARTH_DAY_CLEANUP_MINIGAME_MAX_DURATION,
-        failureReason: "Timeout"
+        failureReason: "Timeout",
+        minigameName: "Earth Day Cleanup"
       });
       await safeEdit(ctx, await buildTreeDisplayMessage(ctx));
     }, EARTH_DAY_CLEANUP_MINIGAME_MAX_DURATION);
@@ -73,7 +74,12 @@ export class EarthDayCleanupMinigame implements Minigame {
       new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons))
     );
 
-    await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: EARTH_DAY_CLEANUP_MINIGAME_MAX_DURATION });
+    await minigameFinished(ctx, {
+      success: true,
+      difficulty: 1,
+      maxDuration: EARTH_DAY_CLEANUP_MINIGAME_MAX_DURATION,
+      minigameName: "Earth Day Cleanup"
+    });
 
     transitionToDefaultTreeView(ctx);
   }
@@ -98,7 +104,8 @@ export class EarthDayCleanupMinigame implements Minigame {
       success: false,
       difficulty: 1,
       maxDuration: EARTH_DAY_CLEANUP_MINIGAME_MAX_DURATION,
-      failureReason: "Wrong button"
+      failureReason: "Wrong button",
+      minigameName: "Earth Day Cleanup"
     });
 
     transitionToDefaultTreeView(ctx);

--- a/src/minigames/specialDays/FireworksShowMinigame.ts
+++ b/src/minigames/specialDays/FireworksShowMinigame.ts
@@ -44,7 +44,8 @@ export class FireworksShowMinigame implements Minigame {
         success: false,
         difficulty: 1,
         maxDuration: FIREWORKS_SHOW_MINIGAME_MAX_DURATION,
-        failureReason: "Timeout"
+        failureReason: "Timeout",
+        minigameName: "Fireworks Show"
       });
       await safeEdit(ctx, await buildTreeDisplayMessage(ctx));
     }, FIREWORKS_SHOW_MINIGAME_MAX_DURATION);
@@ -72,7 +73,12 @@ export class FireworksShowMinigame implements Minigame {
       ctx,
       new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons))
     );
-    await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: FIREWORKS_SHOW_MINIGAME_MAX_DURATION });
+    await minigameFinished(ctx, {
+      success: true,
+      difficulty: 1,
+      maxDuration: FIREWORKS_SHOW_MINIGAME_MAX_DURATION,
+      minigameName: "Fireworks Show"
+    });
     transitionToDefaultTreeView(ctx);
   }
 
@@ -95,7 +101,8 @@ export class FireworksShowMinigame implements Minigame {
       success: false,
       difficulty: 1,
       maxDuration: FIREWORKS_SHOW_MINIGAME_MAX_DURATION,
-      failureReason: "Wrong button"
+      failureReason: "Wrong button",
+      minigameName: "Fireworks Show"
     });
     transitionToDefaultTreeView(ctx);
   }

--- a/src/minigames/specialDays/HeartCollectionMinigame.ts
+++ b/src/minigames/specialDays/HeartCollectionMinigame.ts
@@ -44,7 +44,8 @@ export class HeartCollectionMinigame implements Minigame {
         success: false,
         difficulty: 1,
         maxDuration: HEART_COLLECTION_MINIGAME_MAX_DURATION,
-        failureReason: "Timeout"
+        failureReason: "Timeout",
+        minigameName: "Heart Collection"
       });
       await safeEdit(ctx, await buildTreeDisplayMessage(ctx));
     }, HEART_COLLECTION_MINIGAME_MAX_DURATION);
@@ -72,7 +73,12 @@ export class HeartCollectionMinigame implements Minigame {
       ctx,
       new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons))
     );
-    await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: HEART_COLLECTION_MINIGAME_MAX_DURATION });
+    await minigameFinished(ctx, {
+      success: true,
+      difficulty: 1,
+      maxDuration: HEART_COLLECTION_MINIGAME_MAX_DURATION,
+      minigameName: "Heart Collection"
+    });
     transitionToDefaultTreeView(ctx);
   }
 
@@ -95,7 +101,8 @@ export class HeartCollectionMinigame implements Minigame {
       success: false,
       difficulty: 1,
       maxDuration: HEART_COLLECTION_MINIGAME_MAX_DURATION,
-      failureReason: "Wrong button"
+      failureReason: "Wrong button",
+      minigameName: "Heart Collection"
     });
     transitionToDefaultTreeView(ctx);
   }

--- a/src/minigames/specialDays/PumpkinHuntMinigame.ts
+++ b/src/minigames/specialDays/PumpkinHuntMinigame.ts
@@ -44,7 +44,8 @@ export class PumpkinHuntMinigame implements Minigame {
         success: false,
         difficulty: 1,
         maxDuration: PUMPKIN_HUNT_MINIGAME_MAX_DURATION,
-        failureReason: "Timeout"
+        failureReason: "Timeout",
+        minigameName: "Pumpkin Hunt"
       });
       await safeEdit(ctx, await buildTreeDisplayMessage(ctx));
     }, PUMPKIN_HUNT_MINIGAME_MAX_DURATION);
@@ -70,7 +71,12 @@ export class PumpkinHuntMinigame implements Minigame {
       ctx,
       new MessageBuilder().addEmbed(embed).addComponents(new ActionRowBuilder().addComponents(...buttons))
     );
-    await minigameFinished(ctx, { success: true, difficulty: 1, maxDuration: PUMPKIN_HUNT_MINIGAME_MAX_DURATION });
+    await minigameFinished(ctx, {
+      success: true,
+      difficulty: 1,
+      maxDuration: PUMPKIN_HUNT_MINIGAME_MAX_DURATION,
+      minigameName: "Pumpkin Hunt"
+    });
     transitionToDefaultTreeView(ctx);
   }
 
@@ -93,7 +99,8 @@ export class PumpkinHuntMinigame implements Minigame {
       success: false,
       difficulty: 1,
       maxDuration: PUMPKIN_HUNT_MINIGAME_MAX_DURATION,
-      failureReason: "Wrong button"
+      failureReason: "Wrong button",
+      minigameName: "Pumpkin Hunt"
     });
     transitionToDefaultTreeView(ctx);
   }

--- a/src/minigames/specialDays/StPatricksDayTreasureHuntMinigame.ts
+++ b/src/minigames/specialDays/StPatricksDayTreasureHuntMinigame.ts
@@ -44,7 +44,8 @@ export class StPatricksDayTreasureHuntMinigame implements Minigame {
         success: false,
         difficulty: 1,
         maxDuration: STPATRICKS_TREASURE_HUNT_MINIGAME_MAX_DURATION,
-        failureReason: "Timeout"
+        failureReason: "Timeout",
+        minigameName: "St. Patrick's Day Treasure Hunt"
       });
       await safeEdit(ctx, await buildTreeDisplayMessage(ctx));
     }, STPATRICKS_TREASURE_HUNT_MINIGAME_MAX_DURATION);
@@ -75,7 +76,8 @@ export class StPatricksDayTreasureHuntMinigame implements Minigame {
     await minigameFinished(ctx, {
       success: true,
       difficulty: 1,
-      maxDuration: STPATRICKS_TREASURE_HUNT_MINIGAME_MAX_DURATION
+      maxDuration: STPATRICKS_TREASURE_HUNT_MINIGAME_MAX_DURATION,
+      minigameName: "St. Patrick's Day Treasure Hunt"
     });
     transitionToDefaultTreeView(ctx);
   }
@@ -99,7 +101,8 @@ export class StPatricksDayTreasureHuntMinigame implements Minigame {
       success: false,
       difficulty: 1,
       maxDuration: STPATRICKS_TREASURE_HUNT_MINIGAME_MAX_DURATION,
-      failureReason: "Wrong button"
+      failureReason: "Wrong button",
+      minigameName: "St. Patrick's Day Treasure Hunt"
     });
     transitionToDefaultTreeView(ctx);
   }

--- a/src/minigames/specialDays/ThanksgivingFeastMinigame.ts
+++ b/src/minigames/specialDays/ThanksgivingFeastMinigame.ts
@@ -46,7 +46,8 @@ export class ThanksgivingFeastMinigame implements Minigame {
         success: false,
         difficulty: 1,
         maxDuration: THANKSGIVING_FEAST_MINIGAME_MAX_DURATION,
-        failureReason: "Timeout"
+        failureReason: "Timeout",
+        minigameName: "Thanksgiving Feast"
       });
       await safeEdit(ctx, await buildTreeDisplayMessage(ctx));
     }, THANKSGIVING_FEAST_MINIGAME_MAX_DURATION);
@@ -77,7 +78,8 @@ export class ThanksgivingFeastMinigame implements Minigame {
     await minigameFinished(ctx, {
       success: true,
       difficulty: 1,
-      maxDuration: THANKSGIVING_FEAST_MINIGAME_MAX_DURATION
+      maxDuration: THANKSGIVING_FEAST_MINIGAME_MAX_DURATION,
+      minigameName: "Thanksgiving Feast"
     });
     transitionToDefaultTreeView(ctx);
   }
@@ -101,7 +103,8 @@ export class ThanksgivingFeastMinigame implements Minigame {
       success: false,
       difficulty: 1,
       maxDuration: THANKSGIVING_FEAST_MINIGAME_MAX_DURATION,
-      failureReason: "Wrong button"
+      failureReason: "Wrong button",
+      minigameName: "Thanksgiving Feast"
     });
     transitionToDefaultTreeView(ctx);
   }

--- a/src/tracing/metrics.ts
+++ b/src/tracing/metrics.ts
@@ -1,4 +1,4 @@
-import { metrics } from "@opentelemetry/api";
+import { metrics, SpanStatusCode, trace } from "@opentelemetry/api";
 import { MeterProvider, PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { Resource } from "@opentelemetry/resources";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
@@ -6,7 +6,8 @@ import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 
 // Common resource attributes
 const resource = new Resource({
-  [ATTR_SERVICE_NAME]: process.env.OTEL_SERVICE_NAME
+  [ATTR_SERVICE_NAME]: process.env.OTEL_SERVICE_NAME,
+  ["deployment.environment.name"]: process.env.DEV_MODE ? "development" : "production"
 });
 
 // Metric exporter setup
@@ -121,5 +122,30 @@ export class Metrics {
     });
 
     mongooseOperationMetric.record(duration, { operation });
+  }
+
+  static recordWateringEvent(userId: string, guildId: string, failed: boolean, failReason?: string): void {
+    const wateringEventMetric = meter.createCounter("watering_events", {
+      description: "Counts the number of watering events"
+    });
+
+    wateringEventMetric.add(1, { user: userId, guild: guildId, failed, failReason });
+  }
+
+  static recordDiscordSendWebhookMessage(content: string): void {
+    const discordWebhookMessageMetric = meter.createCounter("discord_webhook_messages_sent", {
+      description: "Counts the number of Discord webhook messages sent"
+    });
+
+    discordWebhookMessageMetric.add(1, { content });
+  }
+
+  static logError(error: Error | string, spanName: string): void {
+    const tracer = trace.getTracer(process.env.OTEL_SERVICE_NAME ?? "christmas-tree-bot");
+    const span = tracer.startSpan(spanName);
+    const errorString = typeof error === "string" ? error : error.message;
+    span.setStatus({ code: SpanStatusCode.ERROR, message: errorString });
+    span.recordException(error);
+    span.end();
   }
 }

--- a/src/tracing/metrics.ts
+++ b/src/tracing/metrics.ts
@@ -46,6 +46,51 @@ export class Metrics {
     shopPurchaseMetric.add(1, { item: itemName, user: userId, guild: guildId ?? "unknown" });
   }
 
+  static recordBoosterPurchaseMetric(boosterName: string, userId: string, guildId?: string): void {
+    const boosterPurchaseMetric = meter.createCounter("booster_purchases", {
+      description: "Counts the number of booster purchases"
+    });
+
+    boosterPurchaseMetric.add(1, { booster: boosterName, user: userId, guild: guildId ?? "unknown" });
+  }
+
+  static recordComposterUpgradeMetric(
+    userId: string,
+    guildId: string,
+    upgradeType: string,
+    upgradeLevel: number
+  ): void {
+    const composterUpgradeMetric = meter.createCounter("composter_upgrades", {
+      description: "Counts the number of composter upgrades"
+    });
+
+    composterUpgradeMetric.add(1, { user: userId, guild: guildId, upgradeType, upgradeLevel });
+  }
+
+  static recordSendCoinsMetric(senderId: string, recipientId: string, amount: number): void {
+    const sendCoinsMetric = meter.createCounter("coins_sent", {
+      description: "Counts the number of coins sent"
+    });
+
+    sendCoinsMetric.add(1, { sender: senderId, recipient: recipientId, amount });
+  }
+
+  static recordMinigameWinMetric(userId: string, minigameName: string): void {
+    const minigameWinMetric = meter.createCounter("minigame_wins", {
+      description: "Counts the number of minigame wins"
+    });
+
+    minigameWinMetric.add(1, { user: userId, minigame: minigameName });
+  }
+
+  static recordMinigameLossMetric(userId: string, minigameName: string): void {
+    const minigameLossMetric = meter.createCounter("minigame_losses", {
+      description: "Counts the number of minigame losses"
+    });
+
+    minigameLossMetric.add(1, { user: userId, minigame: minigameName });
+  }
+
   static recordCosmeticPurchaseMetric(itemName: string, userId: string, guildId?: string): void {
     const cosmeticPurchaseMetric = meter.createCounter("cosmetic_purchases", {
       description: "Counts the number of cosmetic purchases"
@@ -59,7 +104,7 @@ export class Metrics {
       description: "Counts the number of wheel spins"
     });
 
-    wheelSpinMetric.add(1, { user: userId, guild: guildId, rewardType, rewardAmount });
+    wheelSpinMetric.add(1, { user: userId, guild: guildId, rewardType: rewardType, rewardAmount: rewardAmount });
   }
 
   static recordAdventCalendarWinMetric(userId: string, rewardDetails: string): void {

--- a/src/tracing/pinoLogger.ts
+++ b/src/tracing/pinoLogger.ts
@@ -1,5 +1,0 @@
-import pino from "pino";
-
-export const logger = pino({
-  level: "info"
-});

--- a/src/tracing/pinoLogger.ts
+++ b/src/tracing/pinoLogger.ts
@@ -1,0 +1,5 @@
+import pino from "pino";
+
+export const logger = pino({
+  level: "info"
+});

--- a/src/tracing/sdk.ts
+++ b/src/tracing/sdk.ts
@@ -5,9 +5,10 @@ import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
 import { Resource } from "@opentelemetry/resources";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
-import { MongooseInstrumentation } from '@opentelemetry/instrumentation-mongoose';
-import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
-import { PinoInstrumentation } from '@opentelemetry/instrumentation-pino';
+import { MongooseInstrumentation } from "@opentelemetry/instrumentation-mongoose";
+import { UndiciInstrumentation } from "@opentelemetry/instrumentation-undici";
+import { PinoInstrumentation } from "@opentelemetry/instrumentation-pino";
+import { logger } from "./pinoLogger";
 
 // Common resource attributes
 const resource = new Resource({
@@ -47,14 +48,14 @@ const sdk = new NodeSDK({
 try {
   sdk.start();
 } catch (_) {
-  console.log("Error starting telemetry");
+  logger.info("Error starting telemetry");
 }
 
 // Gracefully shut down the SDK on process exit
 process.on("SIGTERM", () => {
   sdk
     .shutdown()
-    .then(() => console.log("Telemetry terminated"))
-    .catch((error) => console.log("Error terminating telemetry", error))
+    .then(() => logger.info("Telemetry terminated"))
+    .catch((error) => logger.info("Error terminating telemetry", error))
     .finally(() => process.exit(0));
 });

--- a/src/tracing/sdk.ts
+++ b/src/tracing/sdk.ts
@@ -6,6 +6,8 @@ import { Resource } from "@opentelemetry/resources";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { MongooseInstrumentation } from '@opentelemetry/instrumentation-mongoose';
+import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
+import { PinoInstrumentation } from '@opentelemetry/instrumentation-pino';
 
 // Common resource attributes
 const resource = new Resource({
@@ -31,7 +33,12 @@ const metricReader = new PeriodicExportingMetricReader({
 // SDK setup
 const sdk = new NodeSDK({
   traceExporter,
-  instrumentations: [getNodeAutoInstrumentations(), new MongooseInstrumentation()],
+  instrumentations: [
+    getNodeAutoInstrumentations(),
+    new MongooseInstrumentation(),
+    new UndiciInstrumentation(),
+    new PinoInstrumentation()
+  ],
   resource: resource
 });
 

--- a/src/tracing/sdk.ts
+++ b/src/tracing/sdk.ts
@@ -8,11 +8,16 @@ import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { MongooseInstrumentation } from "@opentelemetry/instrumentation-mongoose";
 import { UndiciInstrumentation } from "@opentelemetry/instrumentation-undici";
 import { PinoInstrumentation } from "@opentelemetry/instrumentation-pino";
-import { logger } from "./pinoLogger";
+import pino from "pino";
+
+export const logger = pino({
+  level: "info"
+});
 
 // Common resource attributes
 const resource = new Resource({
-  [ATTR_SERVICE_NAME]: process.env.OTEL_SERVICE_NAME
+  [ATTR_SERVICE_NAME]: process.env.OTEL_SERVICE_NAME,
+  ["deployment.environment.name"]: process.env.DEV_MODE ? "development" : "production"
 });
 
 // Trace exporter setup

--- a/src/tracing/sdk.ts
+++ b/src/tracing/sdk.ts
@@ -10,7 +10,7 @@ import { UndiciInstrumentation } from "@opentelemetry/instrumentation-undici";
 import { PinoInstrumentation } from "@opentelemetry/instrumentation-pino";
 import pino from "pino";
 
-export const logger = pino({
+const logger = pino({
   level: "info"
 });
 

--- a/src/util/TreeWateringNotification.ts
+++ b/src/util/TreeWateringNotification.ts
@@ -1,3 +1,4 @@
+import { logger } from "../tracing/pinoLogger";
 import { sendWebhookMessage, deleteWebhookMessage } from "../util/discord/DiscordWebhookHelper";
 
 export async function sendAndDeleteWebhookMessage(
@@ -15,6 +16,6 @@ export async function sendAndDeleteWebhookMessage(
       await deleteWebhookMessage(webhookId, webhookToken, result.id);
     }, 10 * 1000); // 10 seconds
   } catch (error) {
-    console.error(error);
+    logger.error(error);
   }
 }

--- a/src/util/TreeWateringNotification.ts
+++ b/src/util/TreeWateringNotification.ts
@@ -1,4 +1,9 @@
-import { logger } from "../tracing/pinoLogger";
+import { Metrics } from "../tracing/metrics";
+import pino from "pino";
+
+const logger = pino({
+  level: "info"
+});
 import { sendWebhookMessage, deleteWebhookMessage } from "../util/discord/DiscordWebhookHelper";
 
 export async function sendAndDeleteWebhookMessage(
@@ -8,6 +13,7 @@ export async function sendAndDeleteWebhookMessage(
   content: string
 ): Promise<void> {
   try {
+    Metrics.recordDiscordSendWebhookMessage(content);
     // Send the webhook message
     const messageContent = `<@&${roleId}> ${content}`;
     const result = await sendWebhookMessage(webhookId, webhookToken, messageContent);

--- a/src/util/adventCalendar/AdventCalendarHelper.ts
+++ b/src/util/adventCalendar/AdventCalendarHelper.ts
@@ -117,7 +117,6 @@ export class AdventCalendarHelper {
 
   static getNextClaimDay(claimDate: Date): Date {
     const nextDay = new Date(claimDate.getTime() + SECONDS_IN_A_DAY * MILLISECONDS_IN_A_SECOND);
-    console.log(nextDay, nextDay.getTime());
     return new Date(nextDay.getFullYear(), nextDay.getMonth(), nextDay.getDate(), 0, 0, 0);
   }
 

--- a/src/util/anti-bot/antiBotCleanupTimer.ts
+++ b/src/util/anti-bot/antiBotCleanupTimer.ts
@@ -1,6 +1,10 @@
 import { WateringEvent } from "../../models/WateringEvent";
-import { logger } from "../../tracing/pinoLogger";
 import { cleanOldFailedAttempts } from "./failedAttemptsHelper";
+import pino from "pino";
+
+const logger = pino({
+  level: "info"
+});
 
 const WATERING_EVENT_TTL = 2 * 24 * 60 * 60 * 1000; // 2 days
 

--- a/src/util/anti-bot/antiBotCleanupTimer.ts
+++ b/src/util/anti-bot/antiBotCleanupTimer.ts
@@ -1,4 +1,5 @@
 import { WateringEvent } from "../../models/WateringEvent";
+import { logger } from "../../tracing/pinoLogger";
 import { cleanOldFailedAttempts } from "./failedAttemptsHelper";
 
 const WATERING_EVENT_TTL = 2 * 24 * 60 * 60 * 1000; // 2 days
@@ -20,5 +21,5 @@ async function cleanOldWateringEvents() {
     timestamp: { $lt: cutoffTime }
   });
 
-  console.log("Old watering events cleaned up.");
+  logger.info("Old watering events cleaned up.");
 }

--- a/src/util/anti-bot/failedAttemptsHelper.ts
+++ b/src/util/anti-bot/failedAttemptsHelper.ts
@@ -1,6 +1,10 @@
 import { FailedAttempt } from "../../models/FailedAttempt";
 import { SlashCommandContext, ButtonContext } from "interactions.ts";
-import { logger } from "../../tracing/pinoLogger";
+import pino from "pino";
+
+const logger = pino({
+  level: "info"
+});
 
 export const AUTOCLICKER_TIMEFRAME = 1000 * 60 * 60; // 1 hour
 

--- a/src/util/anti-bot/failedAttemptsHelper.ts
+++ b/src/util/anti-bot/failedAttemptsHelper.ts
@@ -1,5 +1,6 @@
 import { FailedAttempt } from "../../models/FailedAttempt";
 import { SlashCommandContext, ButtonContext } from "interactions.ts";
+import { logger } from "../../tracing/pinoLogger";
 
 export const AUTOCLICKER_TIMEFRAME = 1000 * 60 * 60; // 1 hour
 
@@ -43,5 +44,5 @@ export async function cleanOldFailedAttempts(): Promise<void> {
     timestamp: { $lt: cutoffTime }
   });
 
-  console.log("Old failed attempts cleaned up.");
+  logger.info("Old failed attempts cleaned up.");
 }

--- a/src/util/anti-bot/flaggingHelper.ts
+++ b/src/util/anti-bot/flaggingHelper.ts
@@ -11,6 +11,7 @@ import {
   EXCESSIVE_WATERING_THRESHOLD
 } from "./antiBotHelper";
 import { UNLEASH_FEATURES, UnleashHelper } from "../unleash/UnleashHelper";
+import { logger } from "../../tracing/pinoLogger";
 
 export const AUTOCLICKER_FAILED_ATTEMPTS_BAN_THRESHOLD = 5; //Number of flags last day to ban
 export const AUTOCLICKER_FLAGGED_TIMEFRAME = 1000 * 60 * 60 * 24; // 24 hours
@@ -20,7 +21,7 @@ export async function banAutoClicker(ctx: SlashCommandContext | ButtonContext<un
   const guildId = ctx.game?.id;
 
   if (!(await BanHelper.isUserBanned(userId))) {
-    console.log(`User ${userId} in guild ${guildId} banned for auto-clicking.`);
+    logger.info(`User ${userId} in guild ${guildId} banned for auto-clicking.`);
     const banReason = await getFlagReasons(ctx);
     BanHelper.banUser(userId, `Auto ban for: ${banReason.join(",")}`, AUTOBAN_TIME);
   }
@@ -86,7 +87,7 @@ export async function flagPotentialAutoClickers(ctx: SlashCommandContext | Butto
   ) {
     const isFlagged = await isUserFlagged(ctx);
     if (!isFlagged) {
-      console.log(
+      logger.info(
         `User ${userId} in guild ${guildId} flagged as potential auto-clicker. User has ${failedAttempts} failed attempts, while only ${AUTOCLICKER_THRESHOLD} are allowed.`
       );
       const flaggedUser = new FlaggedUser({
@@ -106,7 +107,7 @@ export async function flagPotentialAutoClickers(ctx: SlashCommandContext | Butto
   ) {
     const isFlagged = await isUserFlagged(ctx, EXCESSIVE_WATERING_REFLAG_TIMEFRAME);
     if (!isFlagged) {
-      console.log(
+      logger.info(
         `User ${userId} in guild ${guildId} flagged as potential auto-clicker. User has ${excessiveWatering} excessive watering events, while only ${EXCESSIVE_WATERING_THRESHOLD} are allowed.`
       );
       const flaggedUser = new FlaggedUser({
@@ -124,7 +125,7 @@ export async function flagPotentialAutoClickers(ctx: SlashCommandContext | Butto
     flaggedTimes >= AUTOCLICKER_FAILED_ATTEMPTS_BAN_THRESHOLD &&
     UnleashHelper.isEnabled(UNLEASH_FEATURES.autoBan, ctx)
   ) {
-    console.log(`User ${userId} in guild ${guildId} banned for auto-clicking.`);
+    logger.info(`User ${userId} in guild ${guildId} banned for auto-clicking.`);
     banAutoClicker(ctx);
   }
 }

--- a/src/util/anti-bot/flaggingHelper.ts
+++ b/src/util/anti-bot/flaggingHelper.ts
@@ -11,7 +11,11 @@ import {
   EXCESSIVE_WATERING_THRESHOLD
 } from "./antiBotHelper";
 import { UNLEASH_FEATURES, UnleashHelper } from "../unleash/UnleashHelper";
-import { logger } from "../../tracing/pinoLogger";
+import pino from "pino";
+
+const logger = pino({
+  level: "info"
+});
 
 export const AUTOCLICKER_FAILED_ATTEMPTS_BAN_THRESHOLD = 5; //Number of flags last day to ban
 export const AUTOCLICKER_FLAGGED_TIMEFRAME = 1000 * 60 * 60 * 24; // 24 hours

--- a/src/util/api/image-gen/ImageGenApi.ts
+++ b/src/util/api/image-gen/ImageGenApi.ts
@@ -1,4 +1,5 @@
 import { ITreeStyle } from "../../../models/Guild";
+import { logger } from "../../../tracing/pinoLogger";
 import { HasImageReponseType } from "../../types/api/ImageGenApi/HasImageResponseType";
 import { ImageReponse } from "../../types/api/ImageGenApi/ImageResponseType";
 
@@ -13,7 +14,7 @@ export class ImageGenApi {
 
   public async getGeneratedImage(guildId: string, treeLevel: number, treeStyles: ITreeStyle[]): Promise<ImageReponse> {
     treeLevel = Math.floor(treeLevel);
-    console.log(`Getting image for guild ${guildId} and tree level ${treeLevel}`);
+    logger.info(`Getting image for guild ${guildId} and tree level ${treeLevel}`);
     try {
       const response = await fetch(`${this.apiUrl}/api/tree/${guildId}/${treeLevel}/image`, {
         method: "POST",
@@ -24,20 +25,20 @@ export class ImageGenApi {
       });
       return await response.json();
     } catch (error) {
-      console.error(error);
+      logger.error(error);
       return { success: false };
     }
   }
 
   public async getHasGeneratedImage(guildId: string, treeLevel: number): Promise<boolean> {
     treeLevel = Math.floor(treeLevel);
-    console.log(`Checking if image exists for guild ${guildId} and tree level ${treeLevel}`);
+    logger.info(`Checking if image exists for guild ${guildId} and tree level ${treeLevel}`);
     try {
       const response = await fetch(`${this.apiUrl}/api/tree/${guildId}/${treeLevel}/has-image`);
       const jsonResponse = (await response.json()) as HasImageReponseType;
       return jsonResponse.exists;
     } catch (error) {
-      console.error(error);
+      logger.error(error);
       return false;
     }
   }

--- a/src/util/api/image-gen/ImageGenApi.ts
+++ b/src/util/api/image-gen/ImageGenApi.ts
@@ -1,7 +1,11 @@
 import { ITreeStyle } from "../../../models/Guild";
-import { logger } from "../../../tracing/pinoLogger";
 import { HasImageReponseType } from "../../types/api/ImageGenApi/HasImageResponseType";
 import { ImageReponse } from "../../types/api/ImageGenApi/ImageResponseType";
+import pino from "pino";
+
+const logger = pino({
+  level: "info"
+});
 
 export class ImageGenApi {
   private apiUrl: string | undefined = process.env.IMAGE_GEN_API;

--- a/src/util/api/image-styles/ImageStyleApi.ts
+++ b/src/util/api/image-styles/ImageStyleApi.ts
@@ -1,3 +1,4 @@
+import { logger } from "../../../tracing/pinoLogger";
 import { CachedResponse } from "../../types/api/CachedResponseType";
 import { HasImageReponseType } from "../../types/api/ImageGenApi/HasImageResponseType";
 import { ImageReponse } from "../../types/api/ImageGenApi/ImageResponseType";
@@ -27,7 +28,7 @@ export class ImageStylesApi {
       this.cacheStylesResponse(jsonData);
       return jsonData;
     } catch (error) {
-      console.error(error);
+      logger.error(error);
       return { success: false, styles: [] };
     }
   }
@@ -39,7 +40,7 @@ export class ImageStylesApi {
       });
       return await response.json();
     } catch (error) {
-      console.error(error);
+      logger.error(error);
       return { success: false };
     }
   }
@@ -51,7 +52,7 @@ export class ImageStylesApi {
       });
       return await response.json();
     } catch (error) {
-      console.error(error);
+      logger.error(error);
       return { exists: false };
     }
   }
@@ -63,7 +64,7 @@ export class ImageStylesApi {
       });
       return await response.json();
     } catch (error) {
-      console.error(error);
+      logger.error(error);
       return [];
     }
   }
@@ -80,7 +81,7 @@ export class ImageStylesApi {
       this.cacheFestiveStylesResponse(data);
       return data;
     } catch (error) {
-      console.error(error);
+      logger.error(error);
       return { success: false, styles: [] };
     }
   }

--- a/src/util/api/image-styles/ImageStyleApi.ts
+++ b/src/util/api/image-styles/ImageStyleApi.ts
@@ -1,4 +1,8 @@
-import { logger } from "../../../tracing/pinoLogger";
+import pino from "pino";
+
+const logger = pino({
+  level: "info"
+});
 import { CachedResponse } from "../../types/api/CachedResponseType";
 import { HasImageReponseType } from "../../types/api/ImageGenApi/HasImageResponseType";
 import { ImageReponse } from "../../types/api/ImageGenApi/ImageResponseType";

--- a/src/util/api/item-shop/StyleItemShopApi.ts
+++ b/src/util/api/item-shop/StyleItemShopApi.ts
@@ -1,4 +1,8 @@
-import { logger } from "../../../tracing/pinoLogger";
+import pino from "pino";
+
+const logger = pino({
+  level: "info"
+});
 import { CachedResponse } from "../../types/api/CachedResponseType";
 import { DailyItemShopResponse } from "../../types/api/ItemShopApi/DailyItemShopResponseType";
 

--- a/src/util/api/item-shop/StyleItemShopApi.ts
+++ b/src/util/api/item-shop/StyleItemShopApi.ts
@@ -1,3 +1,4 @@
+import { logger } from "../../../tracing/pinoLogger";
 import { CachedResponse } from "../../types/api/CachedResponseType";
 import { DailyItemShopResponse } from "../../types/api/ItemShopApi/DailyItemShopResponseType";
 
@@ -28,7 +29,7 @@ export class StyleItemShopApi {
       this.cacheDailyItemsResponse(jsonData);
       return { data: jsonData, fromCache: false };
     } catch (error) {
-      console.error(error);
+      logger.error(error);
       return {
         data: {
           success: false,

--- a/src/util/bans/BanHelper.ts
+++ b/src/util/bans/BanHelper.ts
@@ -2,6 +2,7 @@ import { EmbedBuilder, MessageBuilder } from "interactions.ts";
 import { BannedUser, IBannedUser } from "../../models/BannedUser";
 import { getRandomElement } from "../helpers/arrayHelper";
 import { CHEATER_CLOWN_EMOJI, SUPPORT_SERVER_INVITE } from "../const";
+import { logger } from "../../tracing/pinoLogger";
 
 const BAN_IMAGES = [
   "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/banned/ban-1.jpg",
@@ -25,7 +26,7 @@ export class BanHelper {
       { upsert: true }
     );
 
-    console.log(`User ${userId} has been banned for reason: ${reason}`);
+    logger.info(`User ${userId} has been banned for reason: ${reason}`);
   }
 
   static async getUserBan(userId: string): Promise<IBannedUser | null> {
@@ -86,7 +87,7 @@ export class BanHelper {
       { userId, $or: [{ timeEnd: { $gte: now } }, { timeEnd: null }] },
       { $set: { timeEnd: now } }
     );
-    console.log(`User ${userId} has been unbanned.`);
+    logger.info(`User ${userId} has been unbanned.`);
   }
 
   static getBanEmbed(username: string): MessageBuilder {

--- a/src/util/bans/BanHelper.ts
+++ b/src/util/bans/BanHelper.ts
@@ -2,7 +2,11 @@ import { EmbedBuilder, MessageBuilder } from "interactions.ts";
 import { BannedUser, IBannedUser } from "../../models/BannedUser";
 import { getRandomElement } from "../helpers/arrayHelper";
 import { CHEATER_CLOWN_EMOJI, SUPPORT_SERVER_INVITE } from "../const";
-import { logger } from "../../tracing/pinoLogger";
+import pino from "pino";
+
+const logger = pino({
+  level: "info"
+});
 
 const BAN_IMAGES = [
   "https://grow-a-christmas-tree.ams3.cdn.digitaloceanspaces.com/banned/ban-1.jpg",

--- a/src/util/discord/DiscordApiExtensions.ts
+++ b/src/util/discord/DiscordApiExtensions.ts
@@ -4,6 +4,7 @@ import { ButtonBuilder as OriginalButtonBuilder } from "interactions.ts";
 import { ButtonStyle } from "discord-api-types/v10";
 import axios from "axios";
 import { BoosterName } from "../booster/BoosterHelper";
+import { logger } from "../../tracing/pinoLogger";
 
 export enum SKU {
   FESTIVE_ENTITLEMENT = "1298016263687110697",
@@ -115,7 +116,7 @@ export async function updateEntitlementsToGame(
 
     await ctx.game.save();
   } catch (error: unknown) {
-    console.error(error);
+    logger.error(error);
   }
 }
 

--- a/src/util/discord/DiscordApiExtensions.ts
+++ b/src/util/discord/DiscordApiExtensions.ts
@@ -4,7 +4,11 @@ import { ButtonBuilder as OriginalButtonBuilder } from "interactions.ts";
 import { ButtonStyle } from "discord-api-types/v10";
 import axios from "axios";
 import { BoosterName } from "../booster/BoosterHelper";
-import { logger } from "../../tracing/pinoLogger";
+import pino from "pino";
+
+const logger = pino({
+  level: "info"
+});
 
 export enum SKU {
   FESTIVE_ENTITLEMENT = "1298016263687110697",

--- a/src/util/discord/DiscordWebhookEvents.ts
+++ b/src/util/discord/DiscordWebhookEvents.ts
@@ -3,9 +3,10 @@ import { EntitlementCreateData } from "../types/discord/DiscordTypeExtension";
 import { WalletHelper } from "../wallet/WalletHelper";
 import { WheelStateHelper } from "../wheel/WheelStateHelper";
 import { Metrics } from "../../tracing/metrics";
+import { logger } from "../../tracing/pinoLogger";
 
 export async function handleEntitlementCreate(data: EntitlementCreateData) {
-  console.log("Entitlement created:", data);
+  logger.info("Entitlement created:", data);
   const userId = data.user_id;
   const skuId = data.sku_id as SKU;
   const reward = SKU_REWARDS[skuId];
@@ -15,17 +16,17 @@ export async function handleEntitlementCreate(data: EntitlementCreateData) {
 
     if (reward.coins > 0) {
       await WalletHelper.addCoins(userId, reward.coins);
-      console.log(`Added ${reward.coins} coins to user ${userId}`);
+      logger.info(`Added ${reward.coins} coins to user ${userId}`);
     }
 
     if (reward.luckyTickets > 0) {
       await WheelStateHelper.addTickets(userId, reward.luckyTickets);
-      console.log(`Added ${reward.luckyTickets} lucky tickets to user ${userId}`);
+      logger.info(`Added ${reward.luckyTickets} lucky tickets to user ${userId}`);
     }
 
     // Log item name and other relevant details when a purchase is made
     Metrics.recordShopPurchaseMetric(skuId, userId, "unknown");
   } else {
-    console.log(`No reward found for SKU ID: ${skuId}`);
+    logger.info(`No reward found for SKU ID: ${skuId}`);
   }
 }

--- a/src/util/discord/DiscordWebhookEvents.ts
+++ b/src/util/discord/DiscordWebhookEvents.ts
@@ -3,7 +3,11 @@ import { EntitlementCreateData } from "../types/discord/DiscordTypeExtension";
 import { WalletHelper } from "../wallet/WalletHelper";
 import { WheelStateHelper } from "../wheel/WheelStateHelper";
 import { Metrics } from "../../tracing/metrics";
-import { logger } from "../../tracing/pinoLogger";
+import pino from "pino";
+
+const logger = pino({
+  level: "info"
+});
 
 export async function handleEntitlementCreate(data: EntitlementCreateData) {
   logger.info("Entitlement created:", data);

--- a/src/util/discord/MessageExtenstions.ts
+++ b/src/util/discord/MessageExtenstions.ts
@@ -8,7 +8,11 @@ import {
   MessageCommandContext
 } from "interactions.ts";
 import { APIMessage } from "discord-api-types/v10";
-import { logger } from "../../tracing/pinoLogger";
+import pino from "pino";
+
+const logger = pino({
+  level: "info"
+});
 
 async function retryOperation<T>(operation: () => Promise<T>, retries = 1): Promise<T | undefined> {
   for (let attempt = 0; attempt <= retries; attempt++) {

--- a/src/util/discord/MessageExtenstions.ts
+++ b/src/util/discord/MessageExtenstions.ts
@@ -8,17 +8,18 @@ import {
   MessageCommandContext
 } from "interactions.ts";
 import { APIMessage } from "discord-api-types/v10";
+import { logger } from "../../tracing/pinoLogger";
 
 async function retryOperation<T>(operation: () => Promise<T>, retries = 1): Promise<T | undefined> {
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
       return await operation().catch((error) => {
-        console.error(`Operation failed on attempt ${attempt + 1}:`, error);
+        logger.error(`Operation failed on attempt ${attempt + 1}:`, error);
         if (attempt === retries) {
-          console.error("Operation failed after all retries");
+          logger.error("Operation failed after all retries");
           return undefined;
         }
-        console.log(`Retrying operation in 1 second...`);
+        logger.info(`Retrying operation in 1 second...`);
       });
     } catch (error) {
       // This catch block is necessary to handle the rethrown error from the .catch block above

--- a/src/util/postFeedback.ts
+++ b/src/util/postFeedback.ts
@@ -1,5 +1,9 @@
 import axios from "axios";
-import { logger } from "../tracing/pinoLogger";
+import pino from "pino";
+
+const logger = pino({
+  level: "info"
+});
 
 export async function postFeedback(feedback: FeedbackPost) {
   try {

--- a/src/util/postFeedback.ts
+++ b/src/util/postFeedback.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { logger } from "../tracing/pinoLogger";
 
 export async function postFeedback(feedback: FeedbackPost) {
   try {
@@ -12,11 +13,11 @@ export async function postFeedback(feedback: FeedbackPost) {
             content: contentPart,
             username: "Christmas Tree Feedback"
           })
-          .catch((e) => console.error(e));
+          .catch((e) => logger.error(e));
       }, index * 500);
     });
   } catch (e: unknown) {
-    console.error(e);
+    logger.error(e);
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1459,6 +1459,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+colorette@^2.0.7:
+  version "2.0.20"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
+  integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
+
 combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
@@ -1493,6 +1498,11 @@ cross-spawn@^7.0.2:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+dateformat@^4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
+  integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
 
 debug@4:
   version "4.3.7"
@@ -1590,6 +1600,13 @@ encoding@^0.1.13:
   integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
   dependencies:
     iconv-lite "^0.6.2"
+
+end-of-stream@^1.1.0:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
+  dependencies:
+    once "^1.4.0"
 
 err-code@^2.0.2:
   version "2.0.3"
@@ -1724,6 +1741,11 @@ fast-content-type-parse@^1.0.0:
   resolved "https://registry.yarnpkg.com/fast-content-type-parse/-/fast-content-type-parse-1.1.0.tgz#4087162bf5af3294d4726ff29b334f72e3a1092c"
   integrity sha512-fBHHqSTFLVnR61C+gltJuE5GkVQMV0S2nqUO8TJ+5Z3qAKG8vAx4FKai1s5jq/inV1+sREynIWSuQ6HgoSXpDQ==
 
+fast-copy@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-3.0.2.tgz#59c68f59ccbcac82050ba992e0d5c389097c9d35"
+  integrity sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==
+
 fast-decode-uri-component@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz#46f8b6c22b30ff7a81357d4f59abfae938202543"
@@ -1775,7 +1797,7 @@ fast-redact@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.5.0.tgz#e9ea02f7e57d0cd8438180083e93077e496285e4"
   integrity sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==
 
-fast-safe-stringify@^2.0.8:
+fast-safe-stringify@^2.0.8, fast-safe-stringify@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
@@ -2043,6 +2065,11 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+help-me@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/help-me/-/help-me-5.0.0.tgz#b1ebe63b967b74060027c2ac61f9be12d354a6f6"
+  integrity sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==
+
 http-cache-semantics@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
@@ -2222,6 +2249,11 @@ jackspeak@^3.1.2:
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
 
+joycon@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"
+  integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
+
 js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
@@ -2374,6 +2406,11 @@ minimatch@^9.0.4:
   integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
   dependencies:
     brace-expansion "^2.0.1"
+
+minimist@^1.2.6:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 minipass-collect@^2.0.1:
   version "2.0.1"
@@ -2545,7 +2582,7 @@ on-exit-leak-free@^2.1.0:
   resolved "https://registry.yarnpkg.com/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz#fed195c9ebddb7d9e4c3842f93f281ac8dadd3b8"
   integrity sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==
 
-once@^1.3.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -2680,6 +2717,25 @@ pino-abstract-transport@^2.0.0:
   integrity sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==
   dependencies:
     split2 "^4.0.0"
+
+pino-pretty@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-13.0.0.tgz#21d57fe940e34f2e279905d7dba2d7e2c4f9bf17"
+  integrity sha512-cQBBIVG3YajgoUjo1FdKVRX6t9XPxwB9lcNJVD5GCnNM4Y6T12YYx8c6zEejxQsU0wrg9TwmDulcE9LR7qcJqA==
+  dependencies:
+    colorette "^2.0.7"
+    dateformat "^4.6.3"
+    fast-copy "^3.0.2"
+    fast-safe-stringify "^2.1.1"
+    help-me "^5.0.0"
+    joycon "^3.1.1"
+    minimist "^1.2.6"
+    on-exit-leak-free "^2.1.0"
+    pino-abstract-transport "^2.0.0"
+    pump "^3.0.0"
+    secure-json-parse "^2.4.0"
+    sonic-boom "^4.0.1"
+    strip-json-comments "^3.1.1"
 
 pino-std-serializers@^3.1.0:
   version "3.2.0"
@@ -2834,6 +2890,14 @@ proxy-from-env@^1.1.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
+pump@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.2.tgz#836f3edd6bc2ee599256c924ffe0d88573ddcbf8"
+  integrity sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -2960,7 +3024,7 @@ safe-stable-stringify@^2.3.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-secure-json-parse@^2.0.0, secure-json-parse@^2.1.0:
+secure-json-parse@^2.0.0, secure-json-parse@^2.1.0, secure-json-parse@^2.4.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-2.7.0.tgz#5a5f9cd6ae47df23dba3151edd06855d47e09862"
   integrity sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1770,6 +1770,11 @@ fast-redact@^3.0.0:
   resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.3.0.tgz#7c83ce3a7be4898241a46560d51de10f653f7634"
   integrity sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==
 
+fast-redact@^3.1.1:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.5.0.tgz#e9ea02f7e57d0cd8438180083e93077e496285e4"
+  integrity sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==
+
 fast-safe-stringify@^2.0.8:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
@@ -2535,6 +2540,11 @@ obuf@~1.1.2:
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
+on-exit-leak-free@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz#fed195c9ebddb7d9e4c3842f93f281ac8dadd3b8"
+  integrity sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==
+
 once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -2664,10 +2674,22 @@ picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+pino-abstract-transport@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz#de241578406ac7b8a33ce0d77ae6e8a0b3b68a60"
+  integrity sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==
+  dependencies:
+    split2 "^4.0.0"
+
 pino-std-serializers@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz#b56487c402d882eb96cd67c257868016b61ad671"
   integrity sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==
+
+pino-std-serializers@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz#7c625038b13718dbbd84ab446bd673dc52259e3b"
+  integrity sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==
 
 pino@^6.13.0:
   version "6.14.0"
@@ -2681,6 +2703,23 @@ pino@^6.13.0:
     process-warning "^1.0.0"
     quick-format-unescaped "^4.0.3"
     sonic-boom "^1.0.2"
+
+pino@^9.5.0:
+  version "9.5.0"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-9.5.0.tgz#a7ef0fea868d22d52d8a4ce46e6e03c5dc46fdd6"
+  integrity sha512-xSEmD4pLnV54t0NOUN16yCl7RIB1c5UUOse5HSyEXtBp+FgFQyPeDutc+Q2ZO7/22vImV7VfEjH/1zV2QuqvYw==
+  dependencies:
+    atomic-sleep "^1.0.0"
+    fast-redact "^3.1.1"
+    on-exit-leak-free "^2.1.0"
+    pino-abstract-transport "^2.0.0"
+    pino-std-serializers "^7.0.0"
+    process-warning "^4.0.0"
+    quick-format-unescaped "^4.0.3"
+    real-require "^0.2.0"
+    safe-stable-stringify "^2.3.1"
+    sonic-boom "^4.0.1"
+    thread-stream "^3.0.0"
 
 postgres-array@~2.0.0:
   version "2.0.0"
@@ -2751,6 +2790,11 @@ process-warning@^1.0.0:
   resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-1.0.0.tgz#980a0b25dc38cd6034181be4b7726d89066b4616"
   integrity sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==
 
+process-warning@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-4.0.0.tgz#581e3a7a1fb456c5f4fd239f76bce75897682d5a"
+  integrity sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw==
+
 promise-retry@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/promise-retry/-/promise-retry-2.0.1.tgz#ff747a13620ab57ba688f5fc67855410c370da22"
@@ -2814,6 +2858,11 @@ raw-body@^2.4.1:
     http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+real-require@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/real-require/-/real-require-0.2.0.tgz#209632dea1810be2ae063a6ac084fee7e33fba78"
+  integrity sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==
 
 redis@^4.1.0:
   version "4.1.0"
@@ -2900,6 +2949,11 @@ safe-regex2@^2.0.0:
   integrity sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==
   dependencies:
     ret "~0.2.0"
+
+safe-stable-stringify@^2.3.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz#4ca2f8e385f2831c432a719b108a3bf7af42a1dd"
+  integrity sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==
 
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
@@ -3000,12 +3054,24 @@ sonic-boom@^1.0.2:
     atomic-sleep "^1.0.0"
     flatstr "^1.0.12"
 
+sonic-boom@^4.0.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-4.2.0.tgz#e59a525f831210fa4ef1896428338641ac1c124d"
+  integrity sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==
+  dependencies:
+    atomic-sleep "^1.0.0"
+
 sparse-bitfield@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz#ff4ae6e68656056ba4b3e792ab3334d38273ca11"
   integrity sha1-/0rm5oZWBWuks+eSqzM004JzyhE=
   dependencies:
     memory-pager "^1.0.2"
+
+split2@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
+  integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
 
 sprintf-js@^1.1.3:
   version "1.1.3"
@@ -3110,6 +3176,13 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+thread-stream@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/thread-stream/-/thread-stream-3.1.0.tgz#4b2ef252a7c215064507d4ef70c05a5e2d34c4f1"
+  integrity sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==
+  dependencies:
+    real-require "^0.2.0"
 
 tiny-lru@^8.0.1:
   version "8.0.2"


### PR DESCRIPTION
Fixes #174

Add OpenTelemetry instrumentation for HTTP API requests and console logs.

* **Dependencies**:
  - Add `@opentelemetry/instrumentation-pino` and `@opentelemetry/instrumentation-undici` to `package.json`.
  - Add `pino` to `package.json`.

* **Tracing SDK**:
  - Import `UndiciInstrumentation` and `PinoInstrumentation` in `src/tracing/sdk.ts`.
  - Add `UndiciInstrumentation` and `PinoInstrumentation` to the `instrumentations` array in the `NodeSDK` configuration.

* **Logging**:
  - Import `pino` in `src/index.ts`.
  - Replace existing console logging statements with `pino` logging statements.
  - Configure `pino` to output logs to the console.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GewoonJaap/grow-a-christmas-tree/pull/175?shareId=81909864-b23d-4aea-aa57-e8835c68e61f).