### PR TITLE
Add more pino logging

### DIFF
--- a/src/commands/RedeemPurchases.ts
+++ b/src/commands/RedeemPurchases.ts
@@ -78,7 +78,7 @@ export class RedeemPurchasesCommand implements ISlashCommand {
           guildId,
           duration: endTime.getTime() - startTime.getTime(),
           message: "Redemption operation completed successfully."
-        });
+        }, `Redemption operation completed successfully for user ${userId} with ${finalCoins - initialCoins} coins and ${finalLuckyTickets - initialLuckyTickets} lucky tickets.`);
 
         return result;
       } catch (error) {
@@ -102,7 +102,7 @@ export class RedeemPurchasesCommand implements ISlashCommand {
           duration: endTime.getTime() - startTime.getTime(),
           error: (error as Error).message,
           message: "Redemption operation failed."
-        });
+        }, `Redemption operation failed for user ${userId}.`);
 
         throw error;
       } finally {
@@ -247,7 +247,7 @@ async function buildRedeemCoinsMessage(ctx: SlashCommandContext | ButtonContext)
           .join(", "),
         guildId: ctx.interaction.guild_id ?? ctx.game?.id ?? "Unknown",
         message: "Redemption operation completed successfully."
-      });
+      }, `Redemption operation completed successfully for user ${userId} with ${totalCoins} coins and ${totalLuckyTickets} lucky tickets.`);
 
       return message.addComponents(actions);
     } catch (error) {
@@ -270,7 +270,7 @@ async function buildRedeemCoinsMessage(ctx: SlashCommandContext | ButtonContext)
         guildId: ctx.interaction.guild_id ?? ctx.game?.id ?? "Unknown",
         error: (error as Error).message,
         message: "Redemption operation failed."
-      });
+      }, `Redemption operation failed for user ${ctx.user.id}.`);
 
       throw error;
     } finally {

--- a/src/commands/Wheel.ts
+++ b/src/commands/Wheel.ts
@@ -130,7 +130,7 @@ async function handleSpin(ctx: ButtonContext): Promise<MessageBuilder> {
       specialDayMultipliers: SpecialDayHelper.getSpecialDayMultipliers(),
       success: false,
       message: "User attempted to spin the wheel without enough tickets."
-    });
+    }, `User ${userId} attempted to spin the wheel without enough tickets.`);
 
     return message;
   }
@@ -157,7 +157,7 @@ async function handleSpin(ctx: ButtonContext): Promise<MessageBuilder> {
       specialDayMultipliers: SpecialDayHelper.getSpecialDayMultipliers(),
       success: false,
       message: "User attempted to spin the wheel but the operation failed."
-    });
+    }, `User ${userId} attempted to spin the wheel but the operation failed.`);
 
     return new MessageBuilder().addEmbed(embed);
   }
@@ -195,7 +195,7 @@ async function handleSpin(ctx: ButtonContext): Promise<MessageBuilder> {
     specialDayMultipliers: SpecialDayHelper.getSpecialDayMultipliers(),
     success: true,
     message: "User successfully spun the wheel and won a reward."
-  });
+  }, `User ${userId} successfully spun the wheel and won ${rewardDescription}.`);
 
   const actionRow = new ActionRowBuilder().addComponents(
     await ctx.manager.components.createInstance("wheel.spin"),

--- a/src/commands/shop/categories/Boosters.ts
+++ b/src/commands/shop/categories/Boosters.ts
@@ -216,7 +216,7 @@ export class Boosters implements PartialCommand {
         guildId,
         duration: endTime.getTime() - startTime.getTime(),
         message: "Booster purchase operation failed due to insufficient coins."
-      });
+      }, `Booster purchase operation failed for user ${userId} due to insufficient coins for ${booster.name}.`);
 
       return new MessageBuilder().addEmbed(embed).addComponents(actionRow);
     }
@@ -251,7 +251,7 @@ export class Boosters implements PartialCommand {
         duration: endTime.getTime() - startTime.getTime(),
         error: "Purchase failed",
         message: "Booster purchase operation failed due to an error."
-      });
+      }, `Booster purchase operation failed for user ${userId} due to an error for ${booster.name}.`);
 
       return new MessageBuilder().addEmbed(embed).addComponents(actionRow);
     }
@@ -288,7 +288,7 @@ export class Boosters implements PartialCommand {
       guildId,
       duration: endTime.getTime() - startTime.getTime(),
       message: "Booster purchase operation completed successfully."
-    });
+    }, `Booster purchase operation completed successfully for user ${userId} with ${wallet.coins - initialCoins} coins for ${booster.name}.`);
 
     return new MessageBuilder().addEmbed(embed).addComponents(actionRow);
   }

--- a/src/commands/shop/categories/Cosmetics.ts
+++ b/src/commands/shop/categories/Cosmetics.ts
@@ -340,7 +340,7 @@ export class Cosmetics implements PartialCommand, DynamicButtonsCommandType {
         guildId,
         duration: endTime.getTime() - startTime.getTime(),
         message: "Cosmetic purchase operation completed successfully."
-      });
+      }, `Cosmetic purchase operation completed successfully for user ${userId} with ${finalCoins - initialCoins} coins for ${styleName}.`);
 
       return new MessageBuilder().addEmbed(embed).addComponents(actionRow);
     } catch (error) {
@@ -358,7 +358,7 @@ export class Cosmetics implements PartialCommand, DynamicButtonsCommandType {
         duration: endTime.getTime() - startTime.getTime(),
         error: (error as Error).message,
         message: "Cosmetic purchase operation failed."
-      });
+      }, `Cosmetic purchase operation failed for user ${userId} with ${initialCoins} coins for ${style?.name ?? "N/A"}.`);
 
       throw error;
     }


### PR DESCRIPTION
Fixes #185

Add pino logging to various operations in the application.

* **Wheel Spin Logging**:
  - Add pino logging for user ID, timestamp, number of tickets before and after the spin, type and amount of reward won, premium access status, special day multipliers, and success or failure of the spin operation in `src/commands/Wheel.ts`.
  - Add messages to the logging.

* **Redeem Purchases Logging**:
  - Add pino logging for user ID, timestamp, number of coins before and after the redemption, number of lucky tickets before and after the redemption, list of boosters applied, success or failure of the redemption operation, special day multipliers, SKU of the redeemed items, display name of the redeemed items, and guild ID where the redemption occurred in `src/commands/RedeemPurchases.ts`.
  - Add messages to the logging.

* **Cosmetic Purchases Logging**:
  - Add pino logging for user ID, timestamp, number of coins before and after the purchase, SKU of the purchased item, display name of the purchased item, success or failure of the purchase operation, special day multipliers, and guild ID where the purchase occurred in `src/commands/shop/categories/Cosmetics.ts`.
  - Add messages to the logging.

* **Booster Purchases Logging**:
  - Add pino logging for user ID, timestamp, number of coins before and after the purchase, name of the purchased booster, cost of the purchased booster, duration of the purchased booster, success or failure of the purchase operation, special day multipliers, and guild ID where the purchase occurred in `src/commands/shop/categories/Boosters.ts`.
  - Add messages to the logging.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GewoonJaap/grow-a-christmas-tree/pull/186?shareId=fcfc4c75-bc04-4aa2-ac89-f211f1489107).